### PR TITLE
Extended the asset method to support requesting assets by type as well.

### DIFF
--- a/src/Charts.php
+++ b/src/Charts.php
@@ -129,8 +129,9 @@ class Charts extends Facade
     /**
      * Return the library assets. Can set the type of assets in the second param for css and js.
      *
-     * @param array $libs
+     * @param array  $libs
      * @param string $type
+     *
      * @return string
      */
     public static function assets($libs = null, $type = null)
@@ -146,7 +147,7 @@ class Charts extends Facade
                 // return all assets of type in requested libs
                 return collect($libs)->reduce(function ($result, $lib) use ($type, $includes) {
                     return ( ! empty($includes[$lib][$type]))
-                        ? $result . implode("\n", $includes[$lib][$type])
+                        ? $result.implode("\n", $includes[$lib][$type])
                         : $result;
                 });
             }
@@ -154,7 +155,7 @@ class Charts extends Facade
             // return all libraries assets that match requested libraries
             return collect($libs)->reduce(function ($result, $lib) use ($includes) {
                 return ( ! empty($includes[$lib]))
-                    ? $result . implode("\n", array_flatten($includes[$lib]))
+                    ? $result.implode("\n", array_flatten($includes[$lib]))
                     : $result;
             });
         }

--- a/src/Charts.php
+++ b/src/Charts.php
@@ -127,11 +127,13 @@ class Charts extends Facade
     }
 
     /**
-     * Return the library assets.
+     * Return the library assets. Can set the type of assets in the second param for css and js.
      *
      * @param array $libs
+     * @param string $type
+     * @return string
      */
-    public static function assets($libs = null)
+    public static function assets($libs = null, $type = null)
     {
         $includes = include __DIR__.'/includes.php';
 
@@ -140,14 +142,29 @@ class Charts extends Facade
         }
 
         if ($libs && is_array($libs)) {
-            $template = $includes['global'];
-            foreach ($libs as $lib) {
-                $template .= $includes[$lib]."\n";
+            if ($type) {
+                // return all assets of type in requested libs
+                return collect($libs)->reduce(function ($result, $lib) use ($type, $includes) {
+                    return ( ! empty($includes[$lib][$type]))
+                        ? $result . implode("\n", $includes[$lib][$type])
+                        : $result;
+                });
             }
 
-            return $template;
+            // return all libraries assets that match requested libraries
+            return collect($libs)->reduce(function ($result, $lib) use ($includes) {
+                return ( ! empty($includes[$lib]))
+                    ? $result . implode("\n", array_flatten($includes[$lib]))
+                    : $result;
+            });
         }
 
-        return implode("\n", $includes);
+        if ($type) {
+            // return all libraries that have requested asset types
+            return implode("\n", array_collapse(array_pluck($includes, $type)));
+        }
+
+        // return all libraries
+        return implode("\n", array_values($includes));
     }
 }

--- a/src/includes.php
+++ b/src/includes.php
@@ -1,38 +1,38 @@
 <?php
 
-$includes['global'] = "<script src='".asset('/vendor/consoletvs/charts/jquery-3.0.0.min.js')."'></script>";
+$includes['global']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/jquery-3.0.0.min.js')."'></script>";
 
-$includes['canvas-gauges'] = "<script src='".asset('/vendor/consoletvs/charts/canvas-gauges/gauge.min.js')."'></script>";
+$includes['canvas-gauges']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/canvas-gauges/gauge.min.js')."'></script>";
 
-$includes['chartist'] = "<script src='".asset('/vendor/consoletvs/charts/chartist/chartist.min.js')."'></script>";
-$includes['chartist'] .= "<link rel='stylesheet' type='text/css' href='".asset('/vendor/consoletvs/charts/chartist/chartist.min.css')."' />";
+$includes['chartist']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/chartist/chartist.min.js')."'></script>";
+$includes['chartist']['css'][] = "<link rel='stylesheet' type='text/css' href='".asset('/vendor/consoletvs/charts/chartist/chartist.min.css')."' />";
 
-$includes['chartjs'] = "<script src='".asset('/vendor/consoletvs/charts/chartjs/Chart.js')."'></script>";
+$includes['chartjs']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/chartjs/Chart.js')."'></script>";
 
-$includes['fusioncharts'] = "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/fusioncharts/fusioncharts.js')."'></script>";
-$includes['fusioncharts'] .= "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/fusioncharts/themes/fusioncharts.theme.fint.js')."'></script>";
+$includes['fusioncharts']['js'][] = "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/fusioncharts/fusioncharts.js')."'></script>";
+$includes['fusioncharts']['js'][] = "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/fusioncharts/themes/fusioncharts.theme.fint.js')."'></script>";
 
-$includes['google'] = "<script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>";
-$includes['google'] .= "<script type='text/javascript' src='https://www.google.com/jsapi'></script>";
-$includes['google'] .= "<script type='text/javascript'>google.charts.load('current', {'packages':['corechart', 'gauge', 'geochart', 'bar', 'line']});</script>";
+$includes['google']['js'][] = "<script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>";
+$includes['google']['js'][] .= "<script type='text/javascript' src='https://www.google.com/jsapi'></script>";
+$includes['google']['js'][] .= "<script type='text/javascript'>google.charts.load('current', {'packages':['corechart', 'gauge', 'geochart', 'bar', 'line']});</script>";
 
-$includes['highcharts'] = "<script src='".asset('/vendor/consoletvs/charts/highcharts/js/highcharts.js')."'></script>";
-$includes['highcharts'] .= "<script src='".asset('/vendor/consoletvs/charts/highcharts/js/modules/exporting.js')."'></script>";
-$includes['highcharts'] .= "<script src='".asset('/vendor/consoletvs/charts/highmaps/js/modules/map.js')."'></script>";
-$includes['highcharts'] .= "<script src='".asset('/vendor/consoletvs/charts/highmaps/js/modules/data.js')."'></script>";
-$includes['highcharts'] .= "<script src='".asset('/vendor/consoletvs/charts/highmaps/maps/world.js')."'></script>";
+$includes['highcharts']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/highcharts/js/highcharts.js')."'></script>";
+$includes['highcharts']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/highcharts/js/modules/exporting.js')."'></script>";
+$includes['highcharts']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/highmaps/js/modules/map.js')."'></script>";
+$includes['highcharts']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/highmaps/js/modules/data.js')."'></script>";
+$includes['highcharts']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/highmaps/maps/world.js')."'></script>";
 
-$includes['justgage'] = "<script src='".asset('/vendor/consoletvs/charts/justgage/raphael-2.1.4.min.js')."'></script>";
-$includes['justgage'] .= "<script src='".asset('/vendor/consoletvs/charts/justgage/justgage.js')."'></script>";
+$includes['justgage']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/justgage/raphael-2.1.4.min.js')."'></script>";
+$includes['justgage']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/justgage/justgage.js')."'></script>";
 
-$includes['morris'] = "<link rel='stylesheet' href='".asset('/vendor/consoletvs/charts/morris/morris.css')."'>";
-$includes['morris'] .= "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/morris/raphael.min.js')."'></script>";
-$includes['morris'] .= "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/morris/morris.min.js')."'></script>";
+$includes['morris']['css'][] = "<link rel='stylesheet' href='".asset('/vendor/consoletvs/charts/morris/morris.css')."'>";
+$includes['morris']['js'][] = "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/morris/raphael.min.js')."'></script>";
+$includes['morris']['js'][] = "<script type='text/javascript' src='".asset('/vendor/consoletvs/charts/morris/morris.min.js')."'></script>";
 
-$includes['plottablejs'] = "<script src='".asset('/vendor/consoletvs/charts/d3/d3.js')."'></script>";
-$includes['plottablejs'] .= "<link rel='stylesheet' href='".asset('/vendor/consoletvs/charts/plottable/plottable.css')."'>";
-$includes['plottablejs'] .= "<script src='".asset('/vendor/consoletvs/charts/plottable/plottable.js')."'></script>";
+$includes['plottablejs']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/d3/d3.js')."'></script>";
+$includes['plottablejs']['css'][] = "<link rel='stylesheet' href='".asset('/vendor/consoletvs/charts/plottable/plottable.css')."'>";
+$includes['plottablejs']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/plottable/plottable.js')."'></script>";
 
-$includes['progressbarjs'] = "<script src='".asset('/vendor/consoletvs/charts/progressbar/progressbar.min.js')."'></script>";
+$includes['progressbarjs']['js'][] = "<script src='".asset('/vendor/consoletvs/charts/progressbar/progressbar.min.js')."'></script>";
 
 return $includes;


### PR DESCRIPTION
I have suggested extending assets functionality to support asset types, as this allows you to specify css in the header and js at the bottom of the page for best practice. Also removed global being always provided as jQuery may have already been included in the app.