### PR TITLE
Allow the user to set a height for responsive charts

### DIFF
--- a/resources/views/_partials/dimension/css.blade.php
+++ b/resources/views/_partials/dimension/css.blade.php
@@ -1,5 +1,7 @@
-@if($model->responsive)
-    height: 100%; width: 100%;
+@if($model->responsive && $model->height)
+    height: {{ $model->height }}px; width: 100%;
+@elseif($model->responsive)
+    height="100%" width="100%"
 @else
     @if($model->height)
         height: {{ $model->height }}px;

--- a/resources/views/_partials/dimension/html.blade.php
+++ b/resources/views/_partials/dimension/html.blade.php
@@ -1,4 +1,6 @@
-@if($model->responsive)
+@if($model->responsive && $model->height)
+    height="{{ $model->height }}" width="100%"
+@elseif($model->responsive)
     height="100%" width="100%"
 @else
     @if($model->height)

--- a/resources/views/_partials/dimension/js.blade.php
+++ b/resources/views/_partials/dimension/js.blade.php
@@ -1,6 +1,8 @@
-@if($model->responsive)
-    height: 100%,
+@if($model->responsive && $model->height)
+    height: {{ $model->height }},
     width: 100%,
+@elseif($model->responsive)
+    height="100%" width="100%"
 @else
     @if($model->height)
         height: {{ $model->height }},


### PR DESCRIPTION
At the moment charts will get a height of 100% if `responsive` is set to `true`. However, this may lead to very small charts if the parent HTML element has no height specified.
Therefore allow the user to set a height for responsive Charts:
```
$chart = Charts::create('line', 'highcharts')
            ->setTitle('My nice chart')
            ->setLabels(['First', 'Second', 'Third'])
            ->setValues([5,10,20])
            ->setHeight(500)
            ->setResponsive(true);
```

To disable a specific height for the chart, use `->setHeight(false)`. 