### PR TITLE
Make titles optional

### DIFF
--- a/resources/views/_partials/container/chartist.blade.php
+++ b/resources/views/_partials/container/chartist.blade.php
@@ -1,7 +1,9 @@
 <div @include('charts::_partials.dimension.html')>
-    <center>
-        <strong>{{ $model->title }}</strong>
-    </center>
+    @if($model->title)
+        <center>
+            <strong>{{ $model->title }}</strong>
+        </center>
+    @endif
 </div>
 
 <div id="{{ $model->id }}" style="@include('charts::_partials.dimension.css')" class="ct-chart ct-perfect-fourth"></div>

--- a/resources/views/_partials/container/div-title2.blade.php
+++ b/resources/views/_partials/container/div-title2.blade.php
@@ -1,7 +1,9 @@
 <div @include('charts::_partials.dimension.css')>
-    <center>
-        <strong>{{ $model->title }}</strong>
-    </center>
+    @if($model->title)
+        <center>
+            <strong>{{ $model->title }}</strong>
+        </center>
+    @endif
 </div>
 
 <div id="{{ $model->id }}" @include('charts::_partials.dimension.html')></div>

--- a/resources/views/_partials/container/div-titled.blade.php
+++ b/resources/views/_partials/container/div-titled.blade.php
@@ -1,7 +1,9 @@
 <div @include('charts::_partials.dimension.css')>
-    <center>
-        <strong>{{ $model->title }}</strong>
-    </center>
+    @if($model->title )
+        <center>
+            <strong>{{ $model->title }}</strong>
+        </center>
+    @endif
 </div>
 
 <center>

--- a/resources/views/canvas-gauges/gauge.blade.php
+++ b/resources/views/canvas-gauges/gauge.blade.php
@@ -14,7 +14,9 @@ $(function (){
         colorNumbers: "{{ $model->colors[0] }}",
       @endif
       @include('charts::_partials.dimension.js')
-      title: "{{ $model->title }}",
+      @if($model->title)
+        title: "{{ $model->title }}",
+      @endif
       value: "{{ $model->values[0] }}",
       units: "{{ $model->element_label }}",
         @if(count($model->values) >= 2 and $model->values[1] <= $model->values[0])

--- a/resources/views/canvas-gauges/gauge.realtime.blade.php
+++ b/resources/views/canvas-gauges/gauge.realtime.blade.php
@@ -14,7 +14,9 @@
             colorNumbers: "{{ $model->colors[0] }}",
           @endif
           @include('charts::_partials.dimension.js')
-          title: "{{ $model->title }}",
+          @if($model->title)
+            title: "{{ $model->title }}",
+          @endif
           value: $model->values ? $model->values[0] : '0'; ,
           units: "{{ $model->element_label }}",
             @if(count($model->values) >= 2 and $model->values[1] <= $model->values[0])

--- a/resources/views/canvas-gauges/temp.blade.php
+++ b/resources/views/canvas-gauges/temp.blade.php
@@ -14,7 +14,9 @@ $(function (){
         colorNumbers: "{{ $model->colors[0] }}",
       @endif
       @include('charts::_partials.dimension.js')
-      title: "{{ $model->title }}",
+      @if($model->title)
+        title: "{{ $model->title }}",
+      @endif
       value: "{{ $model->values[0] }}",
       units: "{{ $model->element_label }}",
         @if(count($model->values) >= 2 and $model->values[1] <= $model->values[0])

--- a/resources/views/canvas-gauges/temp.realtime.blade.php
+++ b/resources/views/canvas-gauges/temp.realtime.blade.php
@@ -14,7 +14,9 @@ $(function (){
         colorNumbers: "{{ $model->colors[0] }}",
       @endif
       @include('charts::_partials.dimension.js')
-      title: "{{ $model->title }}",
+      @if($model->title)
+        title: "{{ $model->title }}",
+      @endif
       value: $model->values ? $model->values[0] : '0'; ,
       units: "{{ $model->element_label }}",
         @if(count($model->values) >= 2 and $model->values[1] <= $model->values[0])

--- a/resources/views/chartjs/area.blade.php
+++ b/resources/views/chartjs/area.blade.php
@@ -34,13 +34,15 @@ var myLineChart = new Chart(ctx, {
     type: 'line',
     data: data,
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
-        title: {
-            display: true,
-            text: "{{ $model->title }}",
-            fontSize: 20,
-        }
+        @if($model->title)
+            title: {
+                display: true,
+                text: "{{ $model->title }}",
+                fontSize: 20,
+            }
+        @endif
     }
 });
 </script>

--- a/resources/views/chartjs/area.multi.blade.php
+++ b/resources/views/chartjs/area.multi.blade.php
@@ -45,13 +45,15 @@ var myLineChart = new Chart(ctx, {
     type: 'line',
     data: data,
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
+        @if($model->title)
         title: {
             display: true,
             text: "{{ $model->title }}",
             fontSize: 20,
         }
+        @endif
     }
 });
 </script>

--- a/resources/views/chartjs/bar.blade.php
+++ b/resources/views/chartjs/bar.blade.php
@@ -37,13 +37,15 @@ var myChart = new Chart(ctx, {
         ]
     },
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
+        @if($model->title)
         title: {
             display: true,
-            text: '$model->title',
+            text: "{{ $model->title }}",
             fontSize: 20,
         },
+        @endif
         scales: {
             yAxes: [{
                 display: true,

--- a/resources/views/chartjs/bar.multi.blade.php
+++ b/resources/views/chartjs/bar.multi.blade.php
@@ -40,14 +40,16 @@ var myChart = new Chart(ctx, {
         ]
     },
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
-        title: {
+            @if($model->title)
+                title: {
             display: true,
-            text: '$model->title',
-            fontSize: 20,
+                text: "{{ $model->title }}",
+                fontSize: 20,
         },
-        scales: {
+        @endif
+            scales: {
             yAxes: [{
                 display: true,
                 ticks: {

--- a/resources/views/chartjs/donut.blade.php
+++ b/resources/views/chartjs/donut.blade.php
@@ -34,13 +34,15 @@ var myChart = new Chart(ctx, {
         }]
     },
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
+        @if($model->title)
         title: {
             display: true,
             text: "{{ $model->title }}",
             fontSize: 20,
         }
+        @endif
     }
 });
 </script>

--- a/resources/views/chartjs/line.blade.php
+++ b/resources/views/chartjs/line.blade.php
@@ -34,13 +34,15 @@ var myLineChart = new Chart(ctx, {
     type: 'line',
     data: data,
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
+        @if($model->title)
         title: {
             display: true,
             text: "{{ $model->title }}",
             fontSize: 20,
         }
+        @endif
     }
 });
 </script>

--- a/resources/views/chartjs/line.multi.blade.php
+++ b/resources/views/chartjs/line.multi.blade.php
@@ -41,13 +41,15 @@ var myLineChart = new Chart(ctx, {
     type: 'line',
     data: data,
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
+        @if($model->title)
         title: {
             display: true,
             text: "{{ $model->title }}",
             fontSize: 20,
         }
+        @endif
     }
 });
 </script>

--- a/resources/views/chartjs/pie.blade.php
+++ b/resources/views/chartjs/pie.blade.php
@@ -34,13 +34,15 @@ var myChart = new Chart(ctx, {
         }]
     },
     options: {
-        responsive: ($model->responsive or !$model->width) ? 'true' : 'false',
+        responsive: {{ $model->responsive or !$model->width ? 'true' : 'false' }},
         maintainAspectRatio: false,
+        @if($model->title)
         title: {
             display: true,
             text: "{{ $model->title }}",
             fontSize: 20,
         }
+        @endif
     }
 });
 </script>

--- a/resources/views/fusioncharts/area.blade.php
+++ b/resources/views/fusioncharts/area.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 @if($model->colors)
                     'paletteColors': "{{ $model->colors[0] }}",

--- a/resources/views/fusioncharts/area.multi.blade.php
+++ b/resources/views/fusioncharts/area.multi.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 'bgColor': '#ffffff',
                 'borderAlpha': '20',

--- a/resources/views/fusioncharts/bar.blade.php
+++ b/resources/views/fusioncharts/bar.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 'paletteColors': '#0075c2',
                 'bgColor': '#ffffff',

--- a/resources/views/fusioncharts/bar.multi.blade.php
+++ b/resources/views/fusioncharts/bar.multi.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 'bgColor': '#ffffff',
                 'borderAlpha': '20',

--- a/resources/views/fusioncharts/donut.blade.php
+++ b/resources/views/fusioncharts/donut.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 'paletteColors': '#0075c2',
                 'bgColor': '#ffffff',

--- a/resources/views/fusioncharts/line.blade.php
+++ b/resources/views/fusioncharts/line.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 @if($model->colors)
                     'paletteColors': "{{ $model->colors[0] }}",

--- a/resources/views/fusioncharts/line.multi.blade.php
+++ b/resources/views/fusioncharts/line.multi.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 'bgColor': '#ffffff',
                 'borderAlpha': '20',

--- a/resources/views/fusioncharts/pie.blade.php
+++ b/resources/views/fusioncharts/pie.blade.php
@@ -10,7 +10,9 @@ FusionCharts.ready(function () {
         dataFormat: 'json',
         dataSource: {
             'chart': {
+                @if($model->title)
                 'caption': "{{ $model->title }}",
+                @endif
                 'yAxisName': "{{ $model->element_label }}",
                 'paletteColors': '#0075c2',
                 'bgColor': '#ffffff',

--- a/resources/views/google/area.blade.php
+++ b/resources/views/google/area.blade.php
@@ -17,7 +17,9 @@ function drawChart() {
     var options = {
         @include('charts::_partials.dimension.js'),
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors: ["{{ $model->colors[0] }}"],
         @endif

--- a/resources/views/google/area.multi.blade.php
+++ b/resources/views/google/area.multi.blade.php
@@ -26,7 +26,9 @@ function drawChart() {
     var options = {
         @include('charts::_partials.dimension.js')
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors:[
                 @foreach($model->colors as $color)

--- a/resources/views/google/bar.blade.php
+++ b/resources/views/google/bar.blade.php
@@ -26,7 +26,9 @@ function drawPieChart() {
         @include('charts::_partials.dimension.js'),
         legend: { position: 'top', alignment: 'end' },
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors:[
                 @foreach($model->colors as $color)

--- a/resources/views/google/bar.multi.blade.php
+++ b/resources/views/google/bar.multi.blade.php
@@ -27,7 +27,9 @@ function drawPieChart() {
         @include('charts::_partials.dimension.js'),
         legend: { position: 'top', alignment: 'end' },
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors:[
                 @foreach($model->colors as $color)

--- a/resources/views/google/donut.blade.php
+++ b/resources/views/google/donut.blade.php
@@ -17,7 +17,9 @@ function drawPieChart() {
         @include('charts::_partials.dimension.js'),
         fontSize: 12,
         pieHole: 0.4,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors:[
                 @foreach($model->colors as $color)

--- a/resources/views/google/line.blade.php
+++ b/resources/views/google/line.blade.php
@@ -17,7 +17,9 @@ function drawChart() {
     var options = {
         @include('charts::_partials.dimension.js'),
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors: ["{{ $model->colors[0] }}"],
         @endif

--- a/resources/views/google/line.multi.blade.php
+++ b/resources/views/google/line.multi.blade.php
@@ -26,7 +26,9 @@ function drawChart() {
     var options = {
         @include('charts::_partials.dimension.js')
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors:[
                 @foreach($model->colors as $color)

--- a/resources/views/google/pie.blade.php
+++ b/resources/views/google/pie.blade.php
@@ -16,7 +16,9 @@ function drawPieChart() {
     var options = {
         @include('charts::_partials.dimension.js'),
         fontSize: 12,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title: "{{ $model->title }}",
+        @endif
         @if($model->colors)
             colors:[
                 @foreach($model->colors as $color)

--- a/resources/views/highcharts/area.blade.php
+++ b/resources/views/highcharts/area.blade.php
@@ -8,10 +8,12 @@ $(function () {
             renderTo:  "{{ $model->id }}",
             @include('charts::_partials.dimension.js')
         },
-        title: {
-            text:  "{{ $model->title }}",
-            x: -20 //center
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         xAxis: {
             categories: [
                 @foreach($model->labels as $label)

--- a/resources/views/highcharts/area.multi.blade.php
+++ b/resources/views/highcharts/area.multi.blade.php
@@ -9,10 +9,12 @@ $(function () {
             renderTo:  "{{ $model->id }}",
             @include('charts::_partials.dimension.js')
         },
-        title: {
-            text:  "{{ $model->title }}",
-            x: -20 //center
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         xAxis: {
             categories: [
                 @foreach($model->labels as $label)

--- a/resources/views/highcharts/area.realtime.blade.php
+++ b/resources/views/highcharts/area.realtime.blade.php
@@ -13,10 +13,12 @@ $(function () {
             },
             @include('charts::_partials.dimension.js')
         },
-        title: {
-            text:  "{{ $model->title }}",
-            x: -20 //center
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         xAxis: {
             type: 'datetime',
         },

--- a/resources/views/highcharts/bar.blade.php
+++ b/resources/views/highcharts/bar.blade.php
@@ -12,9 +12,11 @@ $(function () {
             plotShadow: false,
             type: 'column'
         },
-        title: {
-            text:  "{{ $model->title }}"
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}"
+            },
+        @endif
         plotOptions: {
            column: {
                pointPadding: 0.2,

--- a/resources/views/highcharts/bar.multi.blade.php
+++ b/resources/views/highcharts/bar.multi.blade.php
@@ -12,9 +12,11 @@ $(function () {
             plotShadow: false,
             type: 'column'
         },
-        title: {
-            text:  "{{ $model->title }}"
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}"
+            },
+        @endif
         plotOptions: {
            column: {
                pointPadding: 0.2,

--- a/resources/views/highcharts/bar.realtime.blade.php
+++ b/resources/views/highcharts/bar.realtime.blade.php
@@ -13,10 +13,12 @@ $(function () {
             },
             @include('charts::_partials.dimension.js')
         },
-        title: {
-            text:  "{{ $model->title }}",
-            x: -20 //center
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         xAxis: {
             type: 'datetime',
         },

--- a/resources/views/highcharts/donut.blade.php
+++ b/resources/views/highcharts/donut.blade.php
@@ -12,9 +12,11 @@ $(function () {
             plotShadow: false,
             type: 'pie'
         },
-        title: {
-            text: "{{ $model->title }}",
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}"
+            },
+        @endif
         tooltip: {
             pointFormat: '{point.y} <b>({point.percentage:.1f}%)</strong>'
         },

--- a/resources/views/highcharts/geo.blade.php
+++ b/resources/views/highcharts/geo.blade.php
@@ -18,9 +18,11 @@ $(function () {
             renderTo:  "{{ $model->id }}",
             @include('charts::_partials.dimension.js')
         },
-        title : {
-            text :  "{{ $model->title }}"
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}"
+            },
+        @endif
         mapNavigation: {
             enabled: true,
             enableDoubleClickZoomTo: true

--- a/resources/views/highcharts/line.blade.php
+++ b/resources/views/highcharts/line.blade.php
@@ -7,10 +7,12 @@
                 renderTo: "{{ $model->id }}",
                 @include('charts::_partials.dimension.js')
             },
-            title: {
-                text: "{{ $model->title }}",
-                x: -20
-            },
+            @if($model->title)
+                title: {
+                    text:  "{{ $model->title }}",
+                    x: -20 //center
+                },
+            @endif
             xAxis: {
                 categories: [
                     @foreach($model->labels as $label)

--- a/resources/views/highcharts/line.multi.blade.php
+++ b/resources/views/highcharts/line.multi.blade.php
@@ -8,10 +8,12 @@ $(function () {
             renderTo: "{{ $model->id }}",
             @include('charts::_partials.dimension.js')
         },
-        title: {
-            text: "{{ $model->title }}",
-            x: -20 //center
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         xAxis: {
             categories: [
             @foreach($model->labels as $label)

--- a/resources/views/highcharts/line.realtime.blade.php
+++ b/resources/views/highcharts/line.realtime.blade.php
@@ -12,10 +12,12 @@ $(function () {
             },
             @include('charts::_partials.dimension.js')
         },
-        title: {
-            text:  "{{ $model->title }}",
-            x: -20 //center
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         xAxis: {
             type: 'datetime',
         },

--- a/resources/views/highcharts/pie.blade.php
+++ b/resources/views/highcharts/pie.blade.php
@@ -12,9 +12,12 @@ $(function () {
             plotShadow: false,
             type: 'pie'
         },
-        title: {
-            text: "{{ $model->title }}",
-        },
+        @if($model->title)
+            title: {
+                text:  "{{ $model->title }}",
+                x: -20 //center
+            },
+        @endif
         tooltip: {
             pointFormat: '{point.y} <b>({point.percentage:.1f}%)</strong>'
         },

--- a/resources/views/justgage/gauge.blade.php
+++ b/resources/views/justgage/gauge.blade.php
@@ -24,7 +24,9 @@ $(function() {
         gaugeWidthScale: 0.6,
         pointer: true,
         counter: true,
-        title:  "{{ $model->title }}",
+        @if($model->title)
+            title:  "{{ $model->title }}",
+        @endif
         label: "{{ $model->element_label }}",
         hideInnerShadow: true
     })

--- a/resources/views/justgage/gauge.realtime.blade.php
+++ b/resources/views/justgage/gauge.realtime.blade.php
@@ -25,7 +25,9 @@ $(function() {
         gaugeWidthScale: 0.6,
         pointer: true,
         counter: true,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title:  "{{ $model->title }}",
+        @endif
         label: "{{ $model->element_label }}",
         hideInnerShadow: true
     })

--- a/resources/views/justgage/percentage.blade.php
+++ b/resources/views/justgage/percentage.blade.php
@@ -25,7 +25,9 @@ $(function() {
         donut: true,
         gaugeWidthScale: 0.6,
         counter: true,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title:  "{{ $model->title }}",
+        @endif
         label: "{{ $model->element_label }}",
         hideInnerShadow: true
     })

--- a/resources/views/justgage/percentage.realtime.blade.php
+++ b/resources/views/justgage/percentage.realtime.blade.php
@@ -25,7 +25,9 @@ $(function() {
         donut: true,
         gaugeWidthScale: 0.6,
         counter: true,
-        title: "{{ $model->title }}",
+        @if($model->title)
+            title:  "{{ $model->title }}",
+        @endif
         label: "{{ $model->element_label }}",
         hideInnerShadow: true
     })

--- a/resources/views/material/bar.blade.php
+++ b/resources/views/material/bar.blade.php
@@ -14,7 +14,9 @@ google.charts.load('current', {'packages':['bar']})
 
     var options = {
       chart: {
-        title: "{{ $model->title }}",
+        @if($model->title )
+          title: "{{ $model->title }}",
+        @endif
       },
       @if($model->colors)
         colors: ["{{ $model->colors[0] }}"],

--- a/resources/views/material/bar.multi.blade.php
+++ b/resources/views/material/bar.multi.blade.php
@@ -27,7 +27,9 @@ function drawChart() {
 
     var options = {
         chart: {
+          @if($model->title )
             title: "{{ $model->title }}",
+          @endif
         },
         @if($model->colors) {
             colors: [

--- a/resources/views/material/line.blade.php
+++ b/resources/views/material/line.blade.php
@@ -14,7 +14,9 @@ google.charts.setOnLoadCallback(drawChart)
 
     var options = {
         chart: {
+          @if($model->title )
             title: "{{ $model->title }}",
+          @endif
         },
         @if($model->colors)
             colors: ["{{ $model->colors[0] }}"],

--- a/resources/views/material/line.multi.blade.php
+++ b/resources/views/material/line.multi.blade.php
@@ -26,7 +26,9 @@ google.charts.load('current', {'packages':['bar']})
 
     var options = {
       chart: {
-        title: "{{ $model->title }}",
+        @if($model->title )
+          title: "{{ $model->title }}",
+        @endif
       },
       @if($model->colors) {
           colors: [

--- a/resources/views/plottablejs/area.blade.php
+++ b/resources/views/plottablejs/area.blade.php
@@ -6,11 +6,11 @@
 $(function() {
     @include('charts::plottablejs._data.one')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-    var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+    var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
     var plot = new Plottable.Plots.Area()
         .addDataset(new Plottable.Dataset(data))
@@ -20,13 +20,16 @@ $(function() {
             .attr('stroke', "{{ $model->colors[0] }}")
             .attr('fill', "{{ $model->colors[0] }}")
         @endif
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center')
-    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
+    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center');
 
-    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()

--- a/resources/views/plottablejs/area.multi.blade.php
+++ b/resources/views/plottablejs/area.multi.blade.php
@@ -6,11 +6,11 @@
 $(function() {
     @include('charts::plottablejs._data.multi')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-    var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+    var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
     var plot = new Plottable.Plots.Area()
         @for($i = 0; $i < count($model->datasets) $i++)
@@ -22,13 +22,16 @@ $(function() {
             .attr('stroke', "{{ $model->colors[0] }}")
             .attr('fill', "{{ $model->colors[0] }}")
         @endif
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
-    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
+    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center');
 
-    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()

--- a/resources/views/plottablejs/bar.blade.php
+++ b/resources/views/plottablejs/bar.blade.php
@@ -6,11 +6,11 @@
 $(function() {
     @include('charts::plottablejs._data.one')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-    var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+    var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
     var plot = new Plottable.Plots.Bar()
         .addDataset(new Plottable.Dataset(data))
@@ -19,13 +19,16 @@ $(function() {
         @if($model->colors)
             .attr('fill', function(d) { return d.color; })
         @endif
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center')
-    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
+    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center');
 
-    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()

--- a/resources/views/plottablejs/bar.multi.blade.php
+++ b/resources/views/plottablejs/bar.multi.blade.php
@@ -6,13 +6,13 @@
 $(function() {
     @include('charts::plottablejs._data.multi')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-      var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+      var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
-    var plot = new Plottable.Plots.ClusteredBar()
+    var plot = new Plottable.Plots.ClusteredBar();
       @for($i = 0; $i < count($model->datasets) $i++) {
           .addDataset(new Plottable.Dataset(s{{ $i }}))
       }
@@ -22,16 +22,18 @@ $(function() {
         .attr('stroke', "{{ $model->colors[0] }}")
         .attr('fill', "{{ $model->colors[0] }}")
       @endif
-      .animated(true)
+      .animated(true);
 
-      var title = new Plottable.Components.TitleLabel("{{ $model->title }}")
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
+
+    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}")
         .yAlignment('center');
 
-      var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}")
-      .yAlignment('center')
-
-     var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]])
-     table.renderTo('svg#{{ $model->id }}')
+     var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]]);
+     table.renderTo('svg#{{ $model->id }}');
 
 
     window.addEventListener('resize', function() {

--- a/resources/views/plottablejs/donut.blade.php
+++ b/resources/views/plottablejs/donut.blade.php
@@ -13,7 +13,7 @@ $(function() {
     var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
 
     var reverseMap = {};
-    data.forEach(function(d) { reverseMap[d.y] = d.x;})
+    data.forEach(function(d) { reverseMap[d.y] = d.x;});
 
     var plot = new Plottable.Plots.Pie()
         .addDataset(new Plottable.Dataset(data))
@@ -25,12 +25,15 @@ $(function() {
         .outerRadius(500, yScale)
         .labelsEnabled(true)
         .labelFormatter(function(n){ return reverseMap[n] ;})
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
 
-    var table = new Plottable.Components.Table([[title],[plot]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[title],[plot]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()

--- a/resources/views/plottablejs/line.blade.php
+++ b/resources/views/plottablejs/line.blade.php
@@ -6,11 +6,11 @@
 $(function() {
     @include('charts::plottablejs._data.one')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-    var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+    var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
     var plot = new Plottable.Plots.Line()
         .addDataset(new Plottable.Dataset(data))
@@ -19,13 +19,16 @@ $(function() {
         @if($model->colors)
             .attr('stroke', "{{ $model->colors[0] }}")
         @endif
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
-    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
+    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center');
 
-    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()

--- a/resources/views/plottablejs/line.multi.blade.php
+++ b/resources/views/plottablejs/line.multi.blade.php
@@ -6,11 +6,11 @@
 $(function() {
     @include('charts::plottablejs._data.multi')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-    var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+    var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
     var plot = new Plottable.Plots.Line()
         @for($i = 0; $i < count($model->datasets) $i++)
@@ -21,13 +21,16 @@ $(function() {
         @if($model->colors)
             .attr('stroke', "{{ $model->colors[0] }}")
         @endif
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
-    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
+    var label = new Plottable.Components.AxisLabel("{{ $model->element_label }}").yAlignment('center');
 
-    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[label, title],[yAxis, plot],[null, xAxis]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()

--- a/resources/views/plottablejs/pie.blade.php
+++ b/resources/views/plottablejs/pie.blade.php
@@ -6,14 +6,14 @@
 $(function() {
     @include('charts::plottablejs._data.one')
 
-    var xScale = new Plottable.Scales.Category()
-    var yScale = new Plottable.Scales.Linear()
+    var xScale = new Plottable.Scales.Category();
+    var yScale = new Plottable.Scales.Linear();
 
-    var xAxis = new Plottable.Axes.Category(xScale, 'bottom')
-    var yAxis = new Plottable.Axes.Numeric(yScale, 'left')
+    var xAxis = new Plottable.Axes.Category(xScale, 'bottom');
+    var yAxis = new Plottable.Axes.Numeric(yScale, 'left');
 
     var reverseMap = {};
-    data.forEach(function(d) { reverseMap[d.y] = d.x;})
+    data.forEach(function(d) { reverseMap[d.y] = d.x;});
 
     var plot = new Plottable.Plots.Pie()
         .addDataset(new Plottable.Dataset(data))
@@ -24,12 +24,15 @@ $(function() {
         .labelsEnabled(true)
         .labelFormatter(function(n){ return reverseMap[n] ;})
         .outerRadius(500, yScale)
-        .animated(true)
+        .animated(true);
 
-    var title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center')
+    var title;
+    @if($model->title)
+        title = new Plottable.Components.TitleLabel("{{ $model->title }}").yAlignment('center');
+    @endif
 
-    var table = new Plottable.Components.Table([[title],[plot]])
-    table.renderTo('svg#{{ $model->id }}')
+    var table = new Plottable.Components.Table([[title],[plot]]);
+    table.renderTo('svg#{{ $model->id }}');
 
     window.addEventListener('resize', function() {
         table.redraw()


### PR DESCRIPTION
Makes titles optional for all chart types.
The problem was that for some chart types the title was displayed even if it was set to empty which takes additional space.

The title can now be hidden by using `->setTitle(false)`