### PR TITLE
groupBy relationship column

### DIFF
--- a/src/Builder/Database.php
+++ b/src/Builder/Database.php
@@ -232,11 +232,10 @@ class Database extends Chart
             $relationColumn = explode('.', $relationColumn);
         }
 
-        foreach ($this->data->groupBy($column) as $data)
-        {
+        foreach ($this->data->groupBy($column) as $data) {
             $label = $data[0];
 
-            if(is_null($relationColumn)) {
+            if (is_null($relationColumn)) {
                 $label = $label->$column;
             } else {
                 if (is_array($relationColumn)) {

--- a/src/Builder/Database.php
+++ b/src/Builder/Database.php
@@ -220,13 +220,35 @@ class Database extends Chart
      * Group the data based on the column.
      *
      * @param string $column
+     * @param string $relationColumn
+     * @return $this
      */
-    public function groupBy($column)
+    public function groupBy($column, $relationColumn = null)
     {
         $labels = [];
         $values = [];
-        foreach ($this->data->groupBy($column) as $data) {
-            array_push($labels, $data[0]->$column);
+
+        if ($relationColumn && strpos($relationColumn, '.') !== false) {
+            $relationColumn = explode('.', $relationColumn);
+        }
+
+        foreach ($this->data->groupBy($column) as $data)
+        {
+            $label = $data[0];
+
+            if(is_null($relationColumn)) {
+                $label = $label->$column;
+            } else {
+                if (is_array($relationColumn)) {
+                    foreach ($relationColumn as $boz) {
+                        $label = $label->$boz;
+                    }
+                } else {
+                    $label = $data[0]->$relationColumn;
+                }
+            }
+
+            array_push($labels, $label);
             array_push($values, count($data));
         }
         $this->labels = $labels;


### PR DESCRIPTION
Added an optional argument to `groupBy()` to set labels based on relationship column.

Assume we have these tables

```
orders
    id - integer
    price - integer
    product_id - integer

product
    id - integer
    model - string
```

and we have `Order` model that have relationship with `Product` model like this:

```
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class Order extends Model
{
    /**
     * Get the ordered product.
     */
    public function product()
    {
        return $this->belongsTo('App\Product');
    }
}
```

I want to create a bar chart of orders group by products:

```
Charts::database(Order::all(), 'bar', 'google')
            ->groupBy('product_id');
```

but the labels would be IDs not the `model` names that I want based on relationship. After this PR we can write:

```
Charts::database(Order::all(), 'bar', 'google')
            ->groupBy('product_id', 'product.model');
```

second argument will set labels to `model` column of `product` table based on it's relationship with `Order` model.