### PR TITLE
Fix operator for PHP versions in Chart.php

### DIFF
--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -270,7 +270,7 @@ class Chart
 
         $this->id = $this->randomString();
         $view = $this->suffix ? "charts::{$this->library}.{$this->suffix}.{$this->type}" : "charts::{$this->library}.{$this->type}";
-        $view = $this->view ?? $view;
+        $view = $this->view ?: $view;
 
         if (View::exists($view)) {
             return view($view)->withModel($this);


### PR DESCRIPTION
Reverted to ternary operator as coalesce operator is only available in  >=php7. This package has has >=5.6.4 requirements.