### PR TITLE
Fixed "Unexpected token {" for Morris donut chart

### DIFF
--- a/resources/views/morris/donut.blade.php
+++ b/resources/views/morris/donut.blade.php
@@ -13,7 +13,7 @@
                     },
                 @endfor
             ],
-            @if($model->colors) {
+            @if($model->colors)
                 colors: [
                     @foreach($model->colors as $c)
                         "{{ $c }}",


### PR DESCRIPTION
There was a "{" character after the check if the model has colors. This broke javascript.