### PR TITLE
Added DB counted procecssing

### DIFF
--- a/docs/3.0/readme.md
+++ b/docs/3.0/readme.md
@@ -400,6 +400,16 @@ The available methods are:
 
     ![Example LastByDay](https://i.gyazo.com/eeac8c7551ed681ef3728454ba4be9f0.png)
 
+- preaggregated(boolean $preaggregated)
+
+    Set to true if using an aggregate database query such as count, max, min, avg, and sum.
+    
+    ```php
+    $data = Orders::select('orders.created_at', DB::raw('count(orders.id) as aggregate'))->groupBy(DB::raw('Date(orders.created_at)'))->get(); //must alias the aggregate column as aggregate
+    
+    $chart = Charts::database($data)->preaggregated(true)->lastByDay(7, false);
+    ```
+
 ## Realtime Charts
 
 ![Realtime Chart Example](https://i.gyazo.com/77a9365e9270cb16a28c6acf11abadc3.gif)

--- a/src/Builder/Database.php
+++ b/src/Builder/Database.php
@@ -94,7 +94,7 @@ class Database extends Chart
      * @param string $month
      * @param bool   $fancy
      */
-    public function groupByHour($day = null, $month = null, $year = null, $fancy = false)
+    public function groupByHour($day = null, $month = null, $year = null, $fancy = false, $precounted = false)
     {
         $labels = [];
         $values = [];
@@ -120,7 +120,9 @@ class Database extends Chart
 
             foreach ($this->data as $data) {
                 if (date('Y-m-d H:00:00', strtotime($data->$date_column)) == $date) {
-                    $value++;
+                    if ($precounted)
+                    {$value = $data->count;}
+                    else {$value++;}
                 }
             }
 
@@ -143,7 +145,7 @@ class Database extends Chart
      * @param string $month
      * @param bool   $fancy
      */
-    public function groupByDay($month = null, $year = null, $fancy = false)
+    public function groupByDay($month = null, $year = null, $fancy = false, $precounted = false)
     {
         $labels = [];
         $values = [];
@@ -168,7 +170,9 @@ class Database extends Chart
 
             foreach ($this->data as $data) {
                 if (date('Y-m-d', strtotime($data->$date_column)) == $date) {
-                    $value++;
+                    if ($precounted)
+                    {$value = $data->count;}
+                    else {$value++;}
                 }
             }
 
@@ -190,7 +194,7 @@ class Database extends Chart
      * @param int  $year
      * @param bool $fancy
      */
-    public function groupByMonth($year = null, $fancy = false)
+    public function groupByMonth($year = null, $fancy = false, $precounted = false)
     {
         $labels = [];
         $values = [];
@@ -217,7 +221,9 @@ class Database extends Chart
                     // Same year
                     if ($month == date('m', strtotime($data->$date_column))) {
                         // Same month
-                        $value++;
+                        if ($precounted)
+                        {$value = $data->count;}
+                        else {$value++;}
                     }
                 }
             }
@@ -235,7 +241,7 @@ class Database extends Chart
      *
      * @param int $number
      */
-    public function groupByYear($number = 4)
+    public function groupByYear($number = 4, $precounted = false)
     {
         $labels = [];
         $values = [];
@@ -254,7 +260,9 @@ class Database extends Chart
             $value = 0;
             foreach ($this->data as $data) {
                 if ($year == date('Y', strtotime($data->$date_column))) {
-                    $value++;
+                    if ($precounted)
+                    {$value = $data->count;}
+                    else {$value++;}
                 }
             }
             array_push($values, $value);
@@ -312,7 +320,7 @@ class Database extends Chart
      * @param int  $number
      * @param bool $number
      */
-    public function lastByDay($number = 7, $fancy = false)
+    public function lastByDay($number = 7, $fancy = false, $precounted = false)
     {
         $labels = [];
         $values = [];
@@ -326,7 +334,9 @@ class Database extends Chart
             $value = 0;
             foreach ($this->data as $data) {
                 if ($date == date('d-m-Y', strtotime($data->$date_column))) {
-                    $value++;
+                    if ($precounted)
+                    {$value = $data->count;}
+                    else {$value++;}
                 }
             }
             array_push($values, $value);
@@ -343,7 +353,7 @@ class Database extends Chart
      * @param int  $number
      * @param bool $number
      */
-    public function lastByMonth($number = 6, $fancy = false)
+    public function lastByMonth($number = 6, $fancy = false, $precounted = false)
     {
         $labels = [];
         $values = [];
@@ -357,7 +367,9 @@ class Database extends Chart
             $value = 0;
             foreach ($this->data as $data) {
                 if ($date == date('m-Y', strtotime($data->$date_column))) {
-                    $value++;
+                    if ($precounted)
+                    {$value = $data->count;}
+                    else {$value++;}
                 }
             }
             array_push($values, $value);

--- a/src/Builder/Database.php
+++ b/src/Builder/Database.php
@@ -22,6 +22,7 @@ class Database extends Chart
     public $date_column;
     public $date_format = 'l dS M, Y';
     public $month_format = 'F, Y';
+    public $preaggregated = false;
 
     /**
      * Create a new database instance.
@@ -88,13 +89,26 @@ class Database extends Chart
     }
 
     /**
+     * Set whether data is preaggregated or should be summed
+     *
+     * @param boolean $preaggregated
+     * @return $this
+     */
+    public function preaggregated($preaggregated)
+    {
+        $this->preaggregated = $preaggregated;
+
+        return $this;
+    }
+
+    /**
      * Group the data hourly based on the creation date.
      *
      * @param string $year
      * @param string $month
      * @param bool   $fancy
      */
-    public function groupByHour($day = null, $month = null, $year = null, $fancy = false, $precounted = false)
+    public function groupByHour($day = null, $month = null, $year = null, $fancy = false)
     {
         $labels = [];
         $values = [];
@@ -120,11 +134,9 @@ class Database extends Chart
 
             foreach ($this->data as $data) {
                 if (date('Y-m-d H:00:00', strtotime($data->$date_column)) == $date) {
-                    if ($precounted) {
-                        $value = $data->count;
-                    } else {
-                        $value++;
-                    }
+                    if ($this->preaggregated)
+                    {$value = $data->aggregate;}
+                    else {$value++;}
                 }
             }
 
@@ -147,7 +159,7 @@ class Database extends Chart
      * @param string $month
      * @param bool   $fancy
      */
-    public function groupByDay($month = null, $year = null, $fancy = false, $precounted = false)
+    public function groupByDay($month = null, $year = null, $fancy = false)
     {
         $labels = [];
         $values = [];
@@ -172,11 +184,9 @@ class Database extends Chart
 
             foreach ($this->data as $data) {
                 if (date('Y-m-d', strtotime($data->$date_column)) == $date) {
-                    if ($precounted) {
-                        $value = $data->count;
-                    } else {
-                        $value++;
-                    }
+                    if ($this->preaggregated)
+                    {$value = $data->aggregate;}
+                    else {$value++;}
                 }
             }
 
@@ -198,7 +208,7 @@ class Database extends Chart
      * @param int  $year
      * @param bool $fancy
      */
-    public function groupByMonth($year = null, $fancy = false, $precounted = false)
+    public function groupByMonth($year = null, $fancy = false)
     {
         $labels = [];
         $values = [];
@@ -225,11 +235,9 @@ class Database extends Chart
                     // Same year
                     if ($month == date('m', strtotime($data->$date_column))) {
                         // Same month
-                        if ($precounted) {
-                            $value = $data->count;
-                        } else {
-                            $value++;
-                        }
+                        if ($this->preaggregated)
+                        {$value = $data->aggregate;}
+                        else {$value++;}
                     }
                 }
             }
@@ -247,7 +255,7 @@ class Database extends Chart
      *
      * @param int $number
      */
-    public function groupByYear($number = 4, $precounted = false)
+    public function groupByYear($number = 4)
     {
         $labels = [];
         $values = [];
@@ -266,11 +274,9 @@ class Database extends Chart
             $value = 0;
             foreach ($this->data as $data) {
                 if ($year == date('Y', strtotime($data->$date_column))) {
-                    if ($precounted) {
-                        $value = $data->count;
-                    } else {
-                        $value++;
-                    }
+                    if ($this->preaggregated)
+                    {$value = $data->aggregate;}
+                    else {$value++;}
                 }
             }
             array_push($values, $value);
@@ -328,7 +334,7 @@ class Database extends Chart
      * @param int  $number
      * @param bool $number
      */
-    public function lastByDay($number = 7, $fancy = false, $precounted = false)
+    public function lastByDay($number = 7, $fancy = false)
     {
         $labels = [];
         $values = [];
@@ -342,11 +348,9 @@ class Database extends Chart
             $value = 0;
             foreach ($this->data as $data) {
                 if ($date == date('d-m-Y', strtotime($data->$date_column))) {
-                    if ($precounted) {
-                        $value = $data->count;
-                    } else {
-                        $value++;
-                    }
+                    if ($this->preaggregated)
+                    {$value = $data->aggregate;}
+                    else {$value++;}
                 }
             }
             array_push($values, $value);
@@ -363,7 +367,7 @@ class Database extends Chart
      * @param int  $number
      * @param bool $number
      */
-    public function lastByMonth($number = 6, $fancy = false, $precounted = false)
+    public function lastByMonth($number = 6, $fancy = false)
     {
         $labels = [];
         $values = [];
@@ -377,11 +381,9 @@ class Database extends Chart
             $value = 0;
             foreach ($this->data as $data) {
                 if ($date == date('m-Y', strtotime($data->$date_column))) {
-                    if ($precounted) {
-                        $value = $data->count;
-                    } else {
-                        $value++;
-                    }
+                    if ($this->preaggregated)
+                    {$value = $data->aggregate;}
+                    else {$value++;}
                 }
             }
             array_push($values, $value);


### PR DESCRIPTION
Example:
     $productData = $product->orders()->select('orders.created_at', DB::raw('count(orders.id) as count'))->groupBy(DB::raw('Date(orders.created_at)'))->get();
     $productData = Charts::database($productData)->lastByDay(7, false, true);


Set precounted to true and pass database results with a count field to create a chart from DB counted data.  Much faster processing than processing in PHP.