### PR TITLE
Highcharts Credits Disable

### DIFF
--- a/docs/3.0/readme.md
+++ b/docs/3.0/readme.md
@@ -946,7 +946,7 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
 
   ### Credits Disable
 
-  Note: ```highcharts``` credits disable available. Default is credits enable.
+  Note: ```highcharts``` credits disable available. Default credits is enable.
 
   ```php
   Charts::multi('line', 'highcharts')->credits(false);

--- a/docs/3.0/readme.md
+++ b/docs/3.0/readme.md
@@ -239,7 +239,7 @@ The available methods are:
 - groupBy(required string $column, optional string $relationColumn, optional array $labelsMapping)
 
     Groups the data based on a column.
-    
+
     *Note:* Relationship column follows this standard: ```->groupBy('product_id', 'product.model');``` where second argument will set labels to model column of product table based on it's relationship with the model.
 
     ```php
@@ -249,11 +249,11 @@ The available methods are:
         ->responsive(false)
         ->groupBy('game');
     ```
-    
+
     ![Example GroupBy](https://i.gyazo.com/30183fa75f6bee6848898c4dbe487491.png)
-    
+
     You can use the $labelsMapping to override labels. The following example overrides the label of different user types stored as integer in database.
-    
+
     ```php
         $chart = Charts::database(User::all(), 'pie', 'highcharts')
             ->title('User types')
@@ -403,10 +403,10 @@ The available methods are:
 - preaggregated(boolean $preaggregated)
 
     Set to true if using an aggregate database query such as count, max, min, avg, and sum.
-    
+
     ```php
     $data = Orders::select('orders.created_at', DB::raw('count(orders.id) as aggregate'))->groupBy(DB::raw('Date(orders.created_at)'))->get(); //must alias the aggregate column as aggregate
-    
+
     $chart = Charts::database($data)->preaggregated(true)->lastByDay(7, false);
     ```
 
@@ -943,6 +943,14 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
   ```
 
   ![Example Progressbar](https://i.gyazo.com/ecd6a20344939ab75767739d32780104.png)
+
+  ### Credits Disable
+
+  Note: ```highcharts``` credits disable available. Default is credits enable.
+
+  ```php
+  Charts::multi('line', 'highcharts')->credits(false);
+  ```
 
 
 ## Extend your way!

--- a/resources/views/highcharts/area.blade.php
+++ b/resources/views/highcharts/area.blade.php
@@ -12,6 +12,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             xAxis: {
                 categories: [
                     @foreach($model->labels as $label)

--- a/resources/views/highcharts/bar.blade.php
+++ b/resources/views/highcharts/bar.blade.php
@@ -14,6 +14,11 @@
                     text:  "{{ $model->title }}"
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             plotOptions: {
                column: {
                    pointPadding: 0.2,

--- a/resources/views/highcharts/donut.blade.php
+++ b/resources/views/highcharts/donut.blade.php
@@ -14,6 +14,11 @@
                     text:  "{{ $model->title }}"
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             tooltip: {
                 pointFormat: '{point.y} <b>({point.percentage:.1f}%)</strong>'
             },

--- a/resources/views/highcharts/geo.blade.php
+++ b/resources/views/highcharts/geo.blade.php
@@ -24,6 +24,11 @@
                     text:  "{{ $model->title }}"
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             mapNavigation: {
                 enabled: true,
                 enableDoubleClickZoomTo: true

--- a/resources/views/highcharts/line.blade.php
+++ b/resources/views/highcharts/line.blade.php
@@ -11,6 +11,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             xAxis: {
                 categories: [
                     @foreach($model->labels as $label)

--- a/resources/views/highcharts/multi/area.blade.php
+++ b/resources/views/highcharts/multi/area.blade.php
@@ -12,6 +12,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif    
             xAxis: {
                 categories: [
                     @foreach($model->labels as $label)

--- a/resources/views/highcharts/multi/bar.blade.php
+++ b/resources/views/highcharts/multi/bar.blade.php
@@ -14,6 +14,11 @@
                     text:  "{{ $model->title }}"
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             plotOptions: {
                column: {
                    pointPadding: 0.2,

--- a/resources/views/highcharts/multi/line.blade.php
+++ b/resources/views/highcharts/multi/line.blade.php
@@ -11,6 +11,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             xAxis: {
                 categories: [
                 @foreach($model->labels as $label)

--- a/resources/views/highcharts/pie.blade.php
+++ b/resources/views/highcharts/pie.blade.php
@@ -15,6 +15,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             tooltip: {
                 pointFormat: '{point.y} <b>({point.percentage:.1f}%)</strong>'
             },

--- a/resources/views/highcharts/realtime/area.blade.php
+++ b/resources/views/highcharts/realtime/area.blade.php
@@ -17,6 +17,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             xAxis: {
                 type: 'datetime',
             },

--- a/resources/views/highcharts/realtime/bar.blade.php
+++ b/resources/views/highcharts/realtime/bar.blade.php
@@ -17,6 +17,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             xAxis: {
                 type: 'datetime',
             },

--- a/resources/views/highcharts/realtime/line.blade.php
+++ b/resources/views/highcharts/realtime/line.blade.php
@@ -16,6 +16,11 @@
                     x: -20 //center
                 },
             @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif
             xAxis: {
                 type: 'datetime',
             },

--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -178,7 +178,7 @@ class Chart
     /**
      * Set chart credits enabled or Disable. Default credits enable.
      *
-     * @param boolean $credits
+     * @param bool $credits
      */
     public function credits($credits)
     {

--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -35,6 +35,7 @@ class Chart
     public $region;
     protected $suffix;
     public $container;
+    public $credits = true;
 
     /**
      * Create a new chart instance.
@@ -170,6 +171,18 @@ class Chart
     public function title($title)
     {
         $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Set chart credits enabled or Disable. Default credits enable.
+     *
+     * @param boolean $credits
+     */
+    public function credits($credits)
+    {
+        $this->credits = $credits;
 
         return $this;
     }


### PR DESCRIPTION
### Credits Disable

  Note: ```highcharts``` credits disable available. Default credits is enable.

  ```php
  Charts::multi('line', 'highcharts')->credits(false);
  ```