### PR TITLE
Added new chart type areaspline for highcharts

### DIFF
--- a/docs/3.0/readme.md
+++ b/docs/3.0/readme.md
@@ -115,19 +115,19 @@ Example View:
 
 | Create Charts | line | area | bar | pie | donut | geo | gauge | temp | percentage | progressbar | areaspline | 
 |---------------|------|------|-----|-----|-------|-----|-------|------|------------|-------------|------------|
-| chartjs       | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
-| highcharts    | x    | x    | x   | x   | x     | x   | -     | -    | -          | -           | -          |
-| google        | x    | x    | x   | x   | x     | x   | x     | -    | -          | -           | x          |
-| material      | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           | x          |
-| chartist      | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
-| fusioncharts  | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
-| morris        | x    | x    | x   | -   | x     | -   | -     | -    | -          | -           | x          |
-| plottablejs   | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
-| minimalist    | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
-| c3		    | x    | x    | x   | x   | x     | -   | x     | -    | -          | -           | x          |
-| canvas-gauges | -    | -    | -   | -   | -     | -   | x     | x    | -          | -           | x          |
-| justgage      | -    | -    | -   | -   | -     | -   | x     | -    | x          | -           | x          |
-| progressbarjs | -    | -    | -   | -   | -     | -   | -     | -    | x          | x           | x          |
+| chartjs       | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | -          |
+| highcharts    | x    | x    | x   | x   | x     | x   | -     | -    | -          | -           | x          |
+| google        | x    | x    | x   | x   | x     | x   | x     | -    | -          | -           | -          |
+| material      | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           | -          |
+| chartist      | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | -          |
+| fusioncharts  | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | -          |
+| morris        | x    | x    | x   | -   | x     | -   | -     | -    | -          | -           | -          |
+| plottablejs   | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | -          |
+| minimalist    | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | -          |
+| c3		    | x    | x    | x   | x   | x     | -   | x     | -    | -          | -           | -          |
+| canvas-gauges | -    | -    | -   | -   | -     | -   | x     | x    | -          | -           | -          |
+| justgage      | -    | -    | -   | -   | -     | -   | x     | -    | x          | -           | -          |
+| progressbarjs | -    | -    | -   | -   | -     | -   | -     | -    | x          | x           | -          |
 
 The first argument of the create method is the chart type, and the second is the library
 
@@ -144,19 +144,19 @@ Charts::create('line', 'highcharts')
 
 | Multi Dataset Charts | line | area | bar | pie | donut | geo | gauge | temp | percentage | progressbar | areaspline  | 
 |----------------------|------|------|-----|-----|-------|-----|-------|------|------------|-------------|-------------|
-| chartjs              | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| highcharts           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
-| google               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| material             | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| chartist             | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| fusioncharts         | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| morris               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| plottablejs          | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| minimalist           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| c3		    	   | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
-| canvas-gauges        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | x           |
-| justgage             | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | x           |
-| progressbarjs        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | x           |
+| chartjs              | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| highcharts           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| google               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| material             | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| chartist             | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| fusioncharts         | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| morris               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| plottablejs          | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| minimalist           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| c3		    	   | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| canvas-gauges        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | -           |
+| justgage             | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | -           |
+| progressbarjs        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | -           |
 
 To create multi-dataset charts simply add the values using the ```setDataset()``` function!
 

--- a/docs/3.0/readme.md
+++ b/docs/3.0/readme.md
@@ -142,21 +142,21 @@ Charts::create('line', 'highcharts')
 
 ## Multi Datasets Charts
 
-| Multi Dataset Charts | line | area | bar | pie | donut | geo | gauge | temp | percentage | progressbar |
-|----------------------|------|------|-----|-----|-------|-----|-------|------|------------|-------------|
-| chartjs              | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| highcharts           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| google               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| material             | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           |
-| chartist             | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| fusioncharts         | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| morris               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| plottablejs          | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| minimalist           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| c3		    	   | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           |
-| canvas-gauges        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           |
-| justgage             | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           |
-| progressbarjs        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           |
+| Multi Dataset Charts | line | area | bar | pie | donut | geo | gauge | temp | percentage | progressbar | areaspline  | 
+|----------------------|------|------|-----|-----|-------|-----|-------|------|------------|-------------|-------------|
+| chartjs              | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| highcharts           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | -           |
+| google               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| material             | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| chartist             | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| fusioncharts         | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| morris               | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| plottablejs          | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| minimalist           | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| c3		    	   | x    | x    | x   | -   | -     | -   | -     | -    | -          | -           | x           |
+| canvas-gauges        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | x           |
+| justgage             | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | x           |
+| progressbarjs        | -    | -    | -   | -   | -     | -   | -     | -    | -          | -           | x           |
 
 To create multi-dataset charts simply add the values using the ```setDataset()``` function!
 
@@ -847,7 +847,20 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
 
   ![Example Area](https://i.gyazo.com/f6c500cf9bfc2e449d64ee19b7bb809c.png)
 
-
+   ### Areaspline
+   
+   ```php
+  Charts::multi('areaspline', 'highcharts')
+    ->title('My nice chart')
+    ->colors(['#ff0000', '#ffffff'])
+    ->labels(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday','Saturday', 'Sunday'])
+    ->dataset('John', [3, 4, 3, 5, 4, 10, 12])
+    ->dataset('Jane',  [1, 3, 4, 3, 3, 5, 4]);
+   ```
+    
+   ![Example Area](https://s30.postimg.org/6uwe893kx/areaspline.png)
+     
+     
   ### Bar
 
   Note: ```highcharts``` can't change the color of this chart. Well it can but it's complicated, so I leave it here.

--- a/docs/3.0/readme.md
+++ b/docs/3.0/readme.md
@@ -113,21 +113,21 @@ Example View:
 
 ## Create Charts
 
-| Create Charts | line | area | bar | pie | donut | geo | gauge | temp | percentage | progressbar |
-|---------------|------|------|-----|-----|-------|-----|-------|------|------------|-------------|
-| chartjs       | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           |
-| highcharts    | x    | x    | x   | x   | x     | x   | -     | -    | -          | -           |
-| google        | x    | x    | x   | x   | x     | x   | x     | -    | -          | -           |
-| material      | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           |
-| chartist      | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           |
-| fusioncharts  | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           |
-| morris        | x    | x    | x   | -   | x     | -   | -     | -    | -          | -           |
-| plottablejs   | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           |
-| minimalist    | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           |
-| c3		    | x    | x    | x   | x   | x     | -   | x     | -    | -          | -           |
-| canvas-gauges | -    | -    | -   | -   | -     | -   | x     | x    | -          | -           |
-| justgage      | -    | -    | -   | -   | -     | -   | x     | -    | x          | -           |
-| progressbarjs | -    | -    | -   | -   | -     | -   | -     | -    | x          | x           |
+| Create Charts | line | area | bar | pie | donut | geo | gauge | temp | percentage | progressbar | areaspline | 
+|---------------|------|------|-----|-----|-------|-----|-------|------|------------|-------------|------------|
+| chartjs       | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
+| highcharts    | x    | x    | x   | x   | x     | x   | -     | -    | -          | -           | -          |
+| google        | x    | x    | x   | x   | x     | x   | x     | -    | -          | -           | x          |
+| material      | x    | -    | x   | -   | -     | -   | -     | -    | -          | -           | x          |
+| chartist      | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
+| fusioncharts  | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
+| morris        | x    | x    | x   | -   | x     | -   | -     | -    | -          | -           | x          |
+| plottablejs   | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
+| minimalist    | x    | x    | x   | x   | x     | -   | -     | -    | -          | -           | x          |
+| c3		    | x    | x    | x   | x   | x     | -   | x     | -    | -          | -           | x          |
+| canvas-gauges | -    | -    | -   | -   | -     | -   | x     | x    | -          | -           | x          |
+| justgage      | -    | -    | -   | -   | -     | -   | x     | -    | x          | -           | x          |
+| progressbarjs | -    | -    | -   | -   | -     | -   | -     | -    | x          | x           | x          |
 
 The first argument of the create method is the chart type, and the second is the library
 

--- a/resources/views/highcharts/multi/areaspline.blade.php
+++ b/resources/views/highcharts/multi/areaspline.blade.php
@@ -1,0 +1,73 @@
+<script type="text/javascript">
+    $(function () {
+        var {{ $model->id }} = new Highcharts.Chart({
+            chart: {
+                type: 'areaspline',
+                renderTo:  "{{ $model->id }}",
+                @include('charts::_partials.dimension.js2')
+            },
+            @if($model->title)
+                title: {
+                    text:  "{{ $model->title }}",
+                    x: -20 //center
+                },
+            @endif
+            @if(!$model->credits)
+                credits: {
+                    enabled: false
+                },
+            @endif    
+            xAxis: {
+                categories: [
+                    @foreach($model->labels as $label)
+                        "{{ $label }}",
+                    @endforeach
+                ],
+                plotBands: [{ // visualize the weekend
+                    from: 4.5,
+                    to: 6.5,
+                    color: 'rgba(68, 170, 213, .2)'
+                }]
+            },
+            yAxis: {
+                title: {
+                    text: "{{ $model->element_label }}"
+                }
+            },
+            legend: {
+                layout: 'vertical',
+                align: 'right',
+                verticalAlign: 'middle',
+                borderWidth: 0
+            },
+            tooltip: {
+                shared: true,
+                valueSuffix: ' units'
+            },
+             plotOptions: {
+                areaspline: {
+                    fillOpacity: 0.5
+                }
+            },
+            series: [
+                @for ($i = 0; $i < count($model->datasets); $i++)
+                    {
+                        name:  "{{ $model->datasets[$i]['label'] }}",
+                        @if($model->colors && count($model->colors) > $i)
+                            color: "{{ $model->colors[$i] }}",
+                        @endif
+                        data: [
+                            @foreach($model->datasets[$i]['values'] as $dta)
+                                {{ $dta }},
+                            @endforeach
+                        ]
+                    },
+                @endfor
+            ]
+        })
+    });
+</script>
+
+@if(!$model->customId)
+    @include('charts::_partials.container.div')
+@endif


### PR DESCRIPTION
Hello,

I have added a new chart type [areaspline](http://www.highcharts.com/demo/areaspline) for highcharts.
Here is the example of using:

  ```
         $chart = Charts::multi('areaspline', 'highcharts')
			     ->title('My nice chart')
			     ->colors(['#ff0000', '#ffffff'])
			     ->labels(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday','Saturday', 'Sunday'])
			    ->dataset('John', [3, 4, 3, 5, 4, 10, 12])
			    ->dataset('Jane',  [1, 3, 4, 3, 3, 5, 4]);
			        
		return view('charts.testchart', ['chart' => $chart]); 
```

If you think it is useful then please accept my pull request.

- Hizbul Bahar
Dhaka, Bangladesh