### PR TITLE
Remove unnecessary Use statement from MultiDatabase

### DIFF
--- a/src/Builder/MultiDatabase.php
+++ b/src/Builder/MultiDatabase.php
@@ -11,8 +11,6 @@
 
 namespace ConsoleTVs\Charts\Builder;
 
-use Database;
-
 /**
  * This is the database class.
  *


### PR DESCRIPTION
Fix the Database not found exception, both classes are in the same
namespace.