### PR TITLE
Comments so PHPStorm throws fewer warnings/find Collection functions.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -15,7 +15,6 @@ use ConsoleTVs\Charts\Builder\Math;
 use ConsoleTVs\Charts\Builder\Chart;
 use ConsoleTVs\Charts\Builder\Multi;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Facade;
 use ConsoleTVs\Charts\Builder\Database;
 use ConsoleTVs\Charts\Builder\Realtime;
 use ConsoleTVs\Charts\Builder\MultiDatabase;
@@ -32,6 +31,8 @@ class Builder
      *
      * @param string $type
      * @param string $library
+     *
+     * @return Chart
      */
     public static function create($type = null, $library = null)
     {
@@ -41,9 +42,12 @@ class Builder
     /**
      * Return a new realtime chart instance.
      *
-     * @param mixed  $data
+     * @param string $url
+     * @param int $interval
      * @param string $type
      * @param string $library
+     *
+     * @return Realtime
      */
     public static function realtime($url, $interval, $type = null, $library = null)
     {
@@ -53,9 +57,11 @@ class Builder
     /**
      * Return a new database chart instance.
      *
-     * @param mixed  $data
+     * @param \Illuminate\Support\Collection $data
      * @param string $type
      * @param string $library
+     *
+     * @return Database
      */
     public static function database($data, $type = null, $library = null)
     {
@@ -70,6 +76,8 @@ class Builder
      * @param int    $amplitude
      * @param string $type
      * @param string $library
+     *
+     * @return Math
      */
     public static function math($function, $interval, $amplitude, $type = null, $library = null)
     {
@@ -81,6 +89,8 @@ class Builder
      *
      * @param string $type
      * @param string $library
+     *
+     * @return Multi
      */
     public static function multi($type = null, $library = null)
     {
@@ -92,6 +102,8 @@ class Builder
      *
      * @param string $type
      * @param string $library
+     *
+     * @return MultiDatabase
      */
     public static function multiDatabase($type = null, $library = null)
     {
@@ -102,6 +114,8 @@ class Builder
      * Return all the libraries available.
      *
      * @param string $type
+     *
+     * @return array
      */
     public static function libraries($type = null)
     {
@@ -131,6 +145,8 @@ class Builder
      * Return all the types available.
      *
      * @param string $library
+     *
+     * @return array
      */
     public static function types($library = null)
     {
@@ -160,6 +176,8 @@ class Builder
        * Return the library styles.
        *
        * @param array  $libraries
+       *
+       * @return string
        */
       public function styles($libraries = [])
       {
@@ -173,6 +191,8 @@ class Builder
         * Return the library scripts.
         *
         * @param array  $libraries
+        *
+        * @return string
         */
        public function scripts($libraries = [])
        {
@@ -186,6 +206,8 @@ class Builder
          * Return the library styles.
          *
          * @param array  $libraries
+         *
+         * @return string
          */
         public function assets($libraries = [])
         {
@@ -198,8 +220,10 @@ class Builder
     /**
      * Get the library assets.
      *
-     * @param array  $libraries
-     * @param string $type
+     * @param array $libraries
+     * @param array $type
+     *
+     * @return string
      */
     private static function getAssets($libraries = [], $type = [])
     {

--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -89,6 +89,8 @@ class Chart
      * Set the chart one color attribute.
      *
      * @param bool $one_color
+     *
+     * @return Chart
      */
     public function oneColor($one_color)
     {
@@ -101,6 +103,8 @@ class Chart
      * Set the chart color template.
      *
      * @param string $template
+     *
+     * @return Chart
      */
     public function template($template)
     {
@@ -113,6 +117,8 @@ class Chart
      * Set the chart division background color.
      *
      * @param string $background_color
+     *
+     * @return Chart
      */
     public function backgroundColor($background_color)
     {
@@ -125,6 +131,8 @@ class Chart
      * Set the loader for the chart.
      *
      * @param bool $loader
+     *
+     * @return Chart
      */
     public function loader($loader)
     {
@@ -137,6 +145,8 @@ class Chart
      * Set a custom loadter time before showing the chart.
      *
      * @param int $loader_duration
+     *
+     * @return Chart
      */
     public function loaderDuration($loader_duration)
     {
@@ -149,6 +159,8 @@ class Chart
      * Set the loader color for the chart if the loader is enabled.
      *
      * @param string $loader_color
+     *
+     * @return Chart
      */
     public function loaderColor($loader_color)
     {
@@ -161,6 +173,8 @@ class Chart
      * Set a custom container to render the chart.
      *
      * @param string $division
+     *
+     * @return Chart
      */
     public function container($division)
     {
@@ -173,6 +187,8 @@ class Chart
      * Set the google geo region.
      *
      * @param string $region
+     *
+     * @return Chart
      */
     public function region($region)
     {
@@ -185,6 +201,8 @@ class Chart
      * Set gauge style.
      *
      * @param string $style
+     *
+     * @return Chart
      */
     public function gaugeStyle($style)
     {
@@ -197,6 +215,8 @@ class Chart
      * Set chart type.
      *
      * @param string $type
+     *
+     * @return Chart
      */
     public function type($type)
     {
@@ -209,6 +229,8 @@ class Chart
      * Set chart library.
      *
      * @param string $library
+     *
+     * @return Chart
      */
     public function library($library)
     {
@@ -221,6 +243,8 @@ class Chart
      * Set chart labels.
      *
      * @param array $labels
+     *
+     * @return Chart
      */
     public function labels($labels)
     {
@@ -233,6 +257,8 @@ class Chart
      * Set chart values.
      *
      * @param array $values
+     *
+     * @return Chart
      */
     public function values($values)
     {
@@ -245,6 +271,8 @@ class Chart
      * Set the chart element label.
      *
      * @param string $label
+     *
+     * @return Chart
      */
     public function elementLabel($label)
     {
@@ -257,6 +285,8 @@ class Chart
      * Set chart title.
      *
      * @param string $title
+     *
+     * @return Chart
      */
     public function title($title)
     {
@@ -269,6 +299,8 @@ class Chart
      * Set chart credits enabled or Disable. Default credits enable.
      *
      * @param bool $credits
+     *
+     * @return Chart
      */
     public function credits($credits)
     {
@@ -281,6 +313,8 @@ class Chart
      * Set chart colors.
      *
      * @param array $colors
+     *
+     * @return Chart
      */
     public function colors($colors)
     {
@@ -293,6 +327,8 @@ class Chart
      * Set chart width.
      *
      * @param int $width
+     *
+     * @return Chart
      */
     public function width($width)
     {
@@ -305,6 +341,8 @@ class Chart
      * Set chart height.
      *
      * @param int $height
+     *
+     * @return Chart
      */
     public function height($height)
     {
@@ -318,6 +356,8 @@ class Chart
      *
      * @param int $width
      * @param int $height
+     *
+     * @return Chart
      */
     public function dimensions($width, $height)
     {
@@ -331,6 +371,8 @@ class Chart
      * Set if chart is responsive (will ignore dimensions if true).
      *
      * @param bool $responsive
+     *
+     * @return Chart
      */
     public function responsive($responsive)
     {
@@ -343,6 +385,8 @@ class Chart
      * Set a custom view to be used.
      *
      * @param string $view
+     *
+     * @return Chart
      */
     public function view($view)
     {
@@ -353,6 +397,8 @@ class Chart
 
     /**
      * Return and array of all the chart settings.
+     *
+     * @return array
      */
     public function settings()
     {
@@ -361,6 +407,8 @@ class Chart
 
     /**
      * Render the chart.
+     *
+     * @return View|string
      */
     public function render()
     {
@@ -457,6 +505,8 @@ class Chart
      * Return a random string.
      *
      * @param int $length
+     *
+     * @return string
      */
     public function randomString($length = 10)
     {

--- a/src/Builder/Database.php
+++ b/src/Builder/Database.php
@@ -19,7 +19,7 @@ namespace ConsoleTVs\Charts\Builder;
 class Database extends Chart
 {
     /**
-     * @var \Illuminate\Support\Collection $data
+     * @var \Illuminate\Support\Collection
      */
     public $data;
     public $date_column;

--- a/src/Builder/Database.php
+++ b/src/Builder/Database.php
@@ -18,6 +18,9 @@ namespace ConsoleTVs\Charts\Builder;
  */
 class Database extends Chart
 {
+    /**
+     * @var \Illuminate\Support\Collection $data
+     */
     public $data;
     public $date_column;
     public $date_format = 'l dS M, Y';
@@ -27,7 +30,7 @@ class Database extends Chart
     /**
      * Create a new database instance.
      *
-     * @param string $data
+     * @param \Illuminate\Support\Collection $data
      * @param string $type
      * @param string $library
      */
@@ -41,9 +44,9 @@ class Database extends Chart
     }
 
     /**
-     * Set chart data.
+     * @param \Illuminate\Support\Collection $data
      *
-     * @param mixed $data
+     * @return Database
      */
     public function data($data)
     {
@@ -56,6 +59,8 @@ class Database extends Chart
      * Set date column to filter the data.
      *
      * @param string $column
+     *
+     * @return Database
      */
     public function dateColumn($column)
     {
@@ -68,6 +73,8 @@ class Database extends Chart
      * Set fancy date format based on PHP date() function.
      *
      * @param string $format
+     *
+     * @return Database
      */
     public function dateFormat($format)
     {
@@ -80,6 +87,8 @@ class Database extends Chart
      * Set fancy month format based on PHP date() function.
      *
      * @param string $format
+     *
+     * @return Database
      */
     public function monthFormat($format)
     {
@@ -92,7 +101,8 @@ class Database extends Chart
      * Set whether data is preaggregated or should be summed.
      *
      * @param bool $preaggregated
-     * @return $this
+     *
+     * @return Database
      */
     public function preaggregated($preaggregated)
     {
@@ -104,9 +114,12 @@ class Database extends Chart
     /**
      * Group the data hourly based on the creation date.
      *
-     * @param string $year
-     * @param string $month
-     * @param bool   $fancy
+     * @param int $day
+     * @param int $month
+     * @param int $year
+     * @param bool $fancy
+     *
+     * @return Database
      */
     public function groupByHour($day = null, $month = null, $year = null, $fancy = false)
     {
@@ -157,9 +170,11 @@ class Database extends Chart
     /**
      * Group the data daily based on the creation date.
      *
-     * @param string $year
-     * @param string $month
-     * @param bool   $fancy
+     * @param int $month
+     * @param int $year
+     * @param bool $fancy
+     *
+     * @return Database
      */
     public function groupByDay($month = null, $year = null, $fancy = false)
     {
@@ -211,6 +226,8 @@ class Database extends Chart
      *
      * @param int  $year
      * @param bool $fancy
+     *
+     * @return Database
      */
     public function groupByMonth($year = null, $fancy = false)
     {
@@ -260,6 +277,8 @@ class Database extends Chart
      * Group the data yearly based on the creation date.
      *
      * @param int $number
+     *
+     * @return Database
      */
     public function groupByYear($number = 4)
     {
@@ -301,7 +320,8 @@ class Database extends Chart
      * @param string $column
      * @param string $relationColumn
      * @param array $labelsMapping
-     * @return $this
+     *
+     * @return Database
      */
     public function groupBy($column, $relationColumn = null, array $labelsMapping = [])
     {
@@ -340,7 +360,9 @@ class Database extends Chart
      * Group the data based on the latest days.
      *
      * @param int  $number
-     * @param bool $number
+     * @param bool $fancy
+     *
+     * @return Database
      */
     public function lastByDay($number = 7, $fancy = false)
     {
@@ -375,7 +397,9 @@ class Database extends Chart
      * Group the data based on the latest months.
      *
      * @param int  $number
-     * @param bool $number
+     * @param bool $fancy
+     *
+     * @return Database
      */
     public function lastByMonth($number = 6, $fancy = false)
     {
@@ -410,6 +434,8 @@ class Database extends Chart
      * Alias for groupByYear().
      *
      * @param int $number
+     *
+     * @return Database
      */
     public function lastByYear($number = 4)
     {

--- a/src/Builder/Math.php
+++ b/src/Builder/Math.php
@@ -49,6 +49,8 @@ class Math extends Chart
      * Set the chart function.
      *
      * @param string $function
+     *
+     * @return Math
      */
     public function mathFunction($function)
     {
@@ -63,6 +65,8 @@ class Math extends Chart
      * Set the function interval.
      *
      * @param array $interval
+     *
+     * @return Math
      */
     public function interval($interval)
     {
@@ -77,6 +81,8 @@ class Math extends Chart
      * Set the function amplitude.
      *
      * @param int $amplitude
+     *
+     * @return Math
      */
     public function amplitude($amplitude)
     {
@@ -90,7 +96,7 @@ class Math extends Chart
     /**
      * Calculates the values.
      *
-     * @param int $amplitude
+     * @return Math
      */
     public function calculate()
     {

--- a/src/Builder/Multi.php
+++ b/src/Builder/Multi.php
@@ -23,9 +23,6 @@ class Multi extends Chart
     /**
      * Create a new multi chart instance.
      *
-     * @param string $function
-     * @param array  $interval
-     * @param int    $amplitude
      * @param string $type
      * @param string $library
      */
@@ -41,6 +38,8 @@ class Multi extends Chart
      *
      * @param string $element_label
      * @param array  $values
+     *
+     * @return Multi
      */
     public function dataset($element_label, $values)
     {

--- a/src/Builder/MultiDatabase.php
+++ b/src/Builder/MultiDatabase.php
@@ -18,6 +18,9 @@ namespace ConsoleTVs\Charts\Builder;
  */
 class MultiDatabase extends Multi
 {
+    /**
+     * @var Database[]
+     */
     public $datas;
     public $date_column = 'created_at';
     public $date_format = 'l dS M, Y';
@@ -27,7 +30,6 @@ class MultiDatabase extends Multi
     /**
      * Create a new database instance.
      *
-     * @param string $data
      * @param string $type
      * @param string $library
      */
@@ -40,7 +42,9 @@ class MultiDatabase extends Multi
      * Set the dataset data.
      *
      * @param string $element_label
-     * @param mixed  $data
+     * @param \Illuminate\Support\Collection $data
+     *
+     * @return MultiDatabase
      */
     public function dataset($element_label, $data)
     {
@@ -53,6 +57,8 @@ class MultiDatabase extends Multi
      * Set date column to filter the data.
      *
      * @param string $column
+     *
+     * @return MultiDatabase
      */
     public function dateColumn($column)
     {
@@ -65,6 +71,8 @@ class MultiDatabase extends Multi
      * Set fancy date format based on PHP date() function.
      *
      * @param string $format
+     *
+     * @return MultiDatabase
      */
     public function dateFormat($format)
     {
@@ -77,6 +85,8 @@ class MultiDatabase extends Multi
      * Set fancy month format based on PHP date() function.
      *
      * @param string $format
+     *
+     * @return MultiDatabase
      */
     public function monthFormat($format)
     {
@@ -89,7 +99,8 @@ class MultiDatabase extends Multi
      * Set whether data is preaggregated or should be summed.
      *
      * @param bool $preaggregated
-     * @return $this
+     *
+     * @return MultiDatabase
      */
     public function preaggregated($preaggregated)
     {
@@ -101,9 +112,12 @@ class MultiDatabase extends Multi
     /**
      * Group the data hourly based on the creation date.
      *
-     * @param string $year
-     * @param string $month
-     * @param bool   $fancy
+     * @param int $day
+     * @param int $month
+     * @param int $year
+     * @param bool $fancy
+     *
+     * @return MultiDatabase
      */
     public function groupByHour($day = null, $month = null, $year = null, $fancy = false)
     {
@@ -123,9 +137,11 @@ class MultiDatabase extends Multi
     /**
      * Group the data daily based on the creation date.
      *
-     * @param string $year
-     * @param string $month
-     * @param bool   $fancy
+     * @param int $month
+     * @param int $year
+     * @param bool $fancy
+     *
+     * @return MultiDatabase
      */
     public function groupByDay($month = null, $year = null, $fancy = false)
     {
@@ -147,6 +163,8 @@ class MultiDatabase extends Multi
      *
      * @param int  $year
      * @param bool $fancy
+     *
+     * @return MultiDatabase
      */
     public function groupByMonth($year = null, $fancy = false)
     {
@@ -167,6 +185,8 @@ class MultiDatabase extends Multi
      * Group the data yearly based on the creation date.
      *
      * @param int $number
+     *
+     * @return MultiDatabase
      */
     public function groupByYear($number = 4)
     {
@@ -189,7 +209,8 @@ class MultiDatabase extends Multi
      * @param string $column
      * @param string $relationColumn
      * @param array $labelsMapping
-     * @return $this
+     *
+     * @return MultiDatabase
      */
     public function groupBy($column, $relationColumn = null, array $labelsMapping = [])
     {
@@ -210,7 +231,9 @@ class MultiDatabase extends Multi
      * Group the data based on the latest days.
      *
      * @param int  $number
-     * @param bool $number
+     * @param bool $fancy
+     *
+     * @return MultiDatabase
      */
     public function lastByDay($number = 7, $fancy = false)
     {
@@ -231,7 +254,9 @@ class MultiDatabase extends Multi
      * Group the data based on the latest months.
      *
      * @param int  $number
-     * @param bool $number
+     * @param bool $fancy
+     *
+     * @return MultiDatabase
      */
     public function lastByMonth($number = 6, $fancy = false)
     {
@@ -252,6 +277,8 @@ class MultiDatabase extends Multi
      * Alias for groupByYear().
      *
      * @param int $number
+     *
+     * @return MultiDatabase
      */
     public function lastByYear($number = 4)
     {

--- a/src/Builder/Realtime.php
+++ b/src/Builder/Realtime.php
@@ -47,6 +47,8 @@ class Realtime extends Chart
      * Set the max values in the chart.
      *
      * @param int $number
+     *
+     * @return Realtime
      */
     public function maxValues($number)
     {
@@ -59,6 +61,8 @@ class Realtime extends Chart
      * Set json value name.
      *
      * @param string $string
+     *
+     * @return Realtime
      */
     public function valueName($string)
     {
@@ -71,6 +75,8 @@ class Realtime extends Chart
      * Set json data streaming url.
      *
      * @param string $url
+     *
+     * @return Realtime
      */
     public function url($url)
     {
@@ -82,7 +88,9 @@ class Realtime extends Chart
     /**
      * Set the update interval in ms.
      *
-     * @param string $url
+     * @param int $interval
+     *
+     * @return Realtime
      */
     public function interval($interval)
     {


### PR DESCRIPTION
 I extend this code in my own projects, but some of the fixes here are universal, thus this commit. In PHPStorm there are several errors due to object references not being found. This changeset forces PHPStorm to find those references to remove the warnings and find the Collection functions so the User can see what the function does. Small cleanup was done in Builder as well. An unused 'use \Illuminate\Support\Facades\Facade;' was removed. In line 237 ($final_assests = $assets;) the variable is set but overwritten before ever referenced again (not changed). In the function getAssets(), the $type is commented as string but defaulted to array (not changed).