### PR TITLE
Add color options to pie chart configuration for Highcharts

### DIFF
--- a/resources/views/highcharts/pie.blade.php
+++ b/resources/views/highcharts/pie.blade.php
@@ -1,6 +1,11 @@
 <script type="text/javascript">
     $(function () {
         var {{ $model->id }} = new Highcharts.Chart({
+            colors: [
+                @foreach($model->colors as $c)
+                    "{{ $c }}",
+                @endforeach
+            ],
             chart: {
                 renderTo: "{{ $model->id }}",
                 @include('charts::_partials.dimension.js2')


### PR DESCRIPTION
According to the Charts documentation Highcharts cannot change the colors of a pie chart, but this does not appear to be the case at this time. Using the same code for setting colors as in the bar charts view for Highcharts allows the pie chart colors to be customized in the same way.