### PR TITLE
Add color options to donut chart for Highcharts and update documentation

### DIFF
--- a/docs/4/readme.md
+++ b/docs/4/readme.md
@@ -913,6 +913,14 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
   Charts::create('line', 'highcharts')->responsive(false);
   ```
 
+- legend(required boolean $legend)
+
+  Set whether to display the chart legend or not. Currently only works with ```highcharts```.
+
+  ```php
+  Charts::create('line', 'highcharts')->legend(false);
+  ```
+
 - settings()
 
   Return the chart settings.
@@ -933,8 +941,6 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
 
   ### Pie
 
-  Note: ```highcharts``` can't change the color of this chart. Well it can but it's complicated, so I leave it here.
-
   ```php
   Charts::create('pie', 'highcharts')
     ->title('My nice chart')
@@ -948,7 +954,7 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
 
   ### Donut / Doughnut
 
-  Note: ```highcharts``` and ```chartist``` can't change the color of this chart. Well they can but it's complicated, so I leave it here.
+  Note: ```chartist``` can't change the color of this chart. Well it can but it's complicated, so I leave it here.
 
   ```php
   Charts::create('donut', 'highcharts')

--- a/resources/views/highcharts/donut.blade.php
+++ b/resources/views/highcharts/donut.blade.php
@@ -1,6 +1,11 @@
 <script type="text/javascript">
     $(function () {
         var {{ $model->id }} = new Highcharts.Chart({
+            colors: [
+                @foreach($model->colors as $c)
+                    "{{ $c }}",
+                @endforeach
+            ],
             chart: {
                 renderTo: "{{ $model->id }}",
                 @include('charts::_partials.dimension.js2')


### PR DESCRIPTION
Add color options to donut chart configuration for Highcharts (as was recently done for pie charts).

Updates documentation:
* Removes notes about Highcharts not being able to set colors of pie and donut charts.
* Adds description of new legend setting under Available Chart Settings.