### PR TITLE
Adds options for setting the titles of the x-axis and y-axis.

### DIFF
--- a/config/charts.php
+++ b/config/charts.php
@@ -21,6 +21,8 @@ return [
         'one_color' => false, // Only use the first color in all values.
         'template' => 'material', // The default chart color template.
         'legend' => true, // Whether to enable the chart legend (where applicable).
+        'x_axis_title' => false, // The title of the x-axis 
+        'y_axis_title' => null, // The title of the y-axis (When set to null will use element_label value).
         'loader' => [
             'active' => true, // Determines the if loader is active by default.
             'duration' => 500, // In milliseconds.

--- a/docs/4/readme.md
+++ b/docs/4/readme.md
@@ -917,8 +917,32 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
 
   Set whether to display the chart legend or not. Currently only works with ```highcharts```.
 
+  *Default:* ```true```
+
   ```php
   Charts::create('line', 'highcharts')->legend(false);
+  ```
+
+- x_axis_title(required boolean $x_axis_title)
+
+  Set title of the x-axis. Currently only works with ```highcharts```.
+
+  *Default:* ```false```
+
+  ```php
+  Charts::create('line', 'highcharts')->x_axis_title('Year');
+  ```
+
+- y_axis_title(required boolean $y_axis_title)
+
+  Set title of the y-axis. Currently only works with ```highcharts```.
+
+  *Default:* ```null```
+
+  *Note:* When set to ```null``` the value for element_label will be used instead.
+
+  ```php
+  Charts::create('line', 'highcharts')->y_axis_title('Number of Units');
   ```
 
 - settings()
@@ -1011,8 +1035,6 @@ The function is ```sin(x)```, the interval is ```[0, 10]``` and the ```x``` ampl
 
 
   ### Bar
-
-  Note: ```highcharts``` can't change the color of this chart. Well it can but it's complicated, so I leave it here.
 
   ```php
   Charts::create('bar', 'highcharts')

--- a/resources/views/highcharts/area.blade.php
+++ b/resources/views/highcharts/area.blade.php
@@ -18,6 +18,9 @@
                 },
             @endif
             xAxis: {
+                title: {
+                    text: "{{ $model->x_axis_title }}"
+                },
                 categories: [
                     @foreach($model->labels as $label)
                         "{{ $label }}",
@@ -26,7 +29,7 @@
             },
             yAxis: {
                 title: {
-                    text: "{{ $model->element_label }}"
+                    text: "{{ $model->y_axis_title === null ? $model->element_label : $model->y_axis_title }}"
                 },
                 plotLines: [{
                     value: 0,

--- a/resources/views/highcharts/bar.blade.php
+++ b/resources/views/highcharts/bar.blade.php
@@ -29,7 +29,10 @@
                     colorByPoint: true,
                 },
             },
-           xAxis: {
+            xAxis: {
+                title: {
+                    text: "{{ $model->x_axis_title }}"
+                },
                 categories: [
                     @foreach($model->labels as $label)
                          "{{ $label }}",
@@ -38,7 +41,7 @@
             },
             yAxis: {
                 title: {
-                    text:  "{{ $model->element_label }}"
+                    text: "{{ $model->y_axis_title === null ? $model->element_label : $model->y_axis_title }}"
                 },
             },
             legend: {

--- a/resources/views/highcharts/line.blade.php
+++ b/resources/views/highcharts/line.blade.php
@@ -17,6 +17,9 @@
                 },
             @endif
             xAxis: {
+                title: {
+                    text: "{{ $model->x_axis_title }}"
+                },
                 categories: [
                     @foreach($model->labels as $label)
                         "{{ $label }}",
@@ -25,7 +28,7 @@
             },
             yAxis: {
                 title: {
-                    text: "{{ $model->element_label }}",
+                    text: "{{ $model->y_axis_title === null ? $model->element_label : $model->y_axis_title }}"
                 },
                 plotLines: [{
                     value: 0,

--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -43,6 +43,9 @@ class Chart
     public $template;
     public $one_color;
     public $legend;
+    public $x_axis_title;
+    public $y_axis_title;
+
 
     /**
      * Create a new chart instance.
@@ -69,6 +72,8 @@ class Chart
         $this->background_color = config('charts.default.background_color');
         $this->credits = false; // Disables the library credits (not on all)
         $this->legend = config('charts.default.legend');
+        $this->x_axis_title = config('charts.default.x_axis_title');
+        $this->y_axis_title = config('charts.default.y_axis_title');
 
         // Setup the chart loader
         $this->loader = config('charts.default.loader.active');
@@ -407,6 +412,34 @@ class Chart
     public function legend($legend)
     {
         $this->legend = $legend;
+
+        return $this;
+    }
+
+    /**
+     * Set the title of a chart's x-axis (where applicable).
+     *
+     * @param bool $x_axis_title
+     *
+     * @return Chart
+     */
+    public function x_axis_title($x_axis_title)
+    {
+        $this->x_axis_title = $x_axis_title;
+
+        return $this;
+    }
+
+    /**
+     * Set the title of a chart's y-axis (where applicable).
+     *
+     * @param bool $y_axis_title
+     *
+     * @return Chart
+     */
+    public function y_axis_title($y_axis_title)
+    {
+        $this->y_axis_title = $y_axis_title;
 
         return $this;
     }


### PR DESCRIPTION
Adds two new chart settings for setting the titles of the x-axis and y-axis. Applies these settings to area, bar, and line charts for Highcharts. Updates the documentation to reflect these new settings.

Note: 
Because the value of the element_label setting was used for the title of the y-axis, this functionality has been preserved. When the value for y_axis_title is set to null (the default value), the value of element_label will be used for the y-axis title instead. All other values for y_axis_title will behave normally. This will allow existing charts to display unchanged until these new settings are utilized. 

Adds Settings:

- x_axis_title
- y_axis_title

Updates Highcharts Charts:

- area
- bar
- line

Updates Documentation:

- Add description of x_axis_title under Available Chart Settings
- Add description of y_axis_title under Available Chart Settings
- Remove note about Highcharts not being able to set colors of bar charts (this functionality was working prior to this commit)