### PR TITLE
Fix: non-english character for some charts

### DIFF
--- a/resources/views/c3/donut.blade.php
+++ b/resources/views/c3/donut.blade.php
@@ -5,7 +5,7 @@ var {{ $model->id }} = c3.generate({
     data: {
         columns: [
             @for($i = 0; $i < count($model->labels); $i++)
-                ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
             @endfor
         ],
         type: 'donut',

--- a/resources/views/c3/pie.blade.php
+++ b/resources/views/c3/pie.blade.php
@@ -5,7 +5,7 @@ var {{ $model->id }} = c3.generate({
     data: {
         columns: [
             @for($i = 0; $i < count($model->labels); $i++)
-                ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
             @endfor
         ],
         type: 'pie',

--- a/resources/views/chartjs/multi/area.blade.php
+++ b/resources/views/chartjs/multi/area.blade.php
@@ -17,7 +17,7 @@
             @for ($i = 0; $i < count($model->datasets); $i++)
                 {
                     fill: true,
-                    label: "{{ $model->datasets[$i]['label'] }}",
+                    label: "{!! $model->datasets[$i]['label'] !!}",
                     lineTension: 0.3,
                     @if($model->colors and count($model->colors) > $i)
                         @php($c = $model->colors[$i])

--- a/resources/views/chartjs/multi/bar.blade.php
+++ b/resources/views/chartjs/multi/bar.blade.php
@@ -16,7 +16,7 @@
                 @for ($i = 0; $i < count($model->datasets); $i++)
                     {
                         fill: true,
-                        label: "{{ $model->datasets[$i]['label'] }}",
+                        label: "{!! $model->datasets[$i]['label'] !!}",
                         lineTension: 0.3,
                         @if($model->colors and count($model->colors) > $i)
                             borderColor: "{{ $model->colors[$i] }}",

--- a/resources/views/chartjs/multi/line.blade.php
+++ b/resources/views/chartjs/multi/line.blade.php
@@ -14,7 +14,7 @@
             @for ($i = 0; $i < count($model->datasets); $i++)
                 {
                     fill: false,
-                    label: "{{ $model->datasets[$i]['label'] }}",
+                    label: "{!! $model->datasets[$i]['label'] !!}",
                     lineTension: 0.3,
                     @if($model->colors and count($model->colors) > $i)
                         @php($c = $model->colors[$i])

--- a/resources/views/fusioncharts/area.blade.php
+++ b/resources/views/fusioncharts/area.blade.php
@@ -35,7 +35,7 @@
                 'data': [
                     @for ($i = 0; $i < count($model->values); $i++)
                         {
-                            'label': "{{ $model->labels[$i] }}",
+                            'label': "{!! $model->labels[$i] !!}",
                             'value': {{ $model->values[$i] }},
                         },
                     @endfor

--- a/resources/views/fusioncharts/bar.blade.php
+++ b/resources/views/fusioncharts/bar.blade.php
@@ -32,7 +32,7 @@
                 'data': [
                     @for ($i = 0; $i < count($model->values); $i++)
                         {
-                            'label': "{{ $model->labels[$i] }}",
+                            'label': "{!! $model->labels[$i] !!}",
                             'value': {{ $model->values[$i] }},
                             @if($model->colors)
                                 'color': "{{ $model->colors[$i] }}",

--- a/resources/views/fusioncharts/donut.blade.php
+++ b/resources/views/fusioncharts/donut.blade.php
@@ -43,7 +43,7 @@
                 'data': [
                     @for ($i = 0; $i < count($model->values); $i++)
                         {
-                            'label': "{{ $model->labels[$i] }}",
+                            'label': "{!! $model->labels[$i] !!}",
                             'value': {{ $model->values[$i] }},
                             @if($model->colors)
                                 'color': "{{ $model->colors[$i] }}",

--- a/resources/views/fusioncharts/line.blade.php
+++ b/resources/views/fusioncharts/line.blade.php
@@ -34,7 +34,7 @@
                 'data': [
                     @for ($i = 0; $i < count($model->values); $i++)
                         {
-                            'label': "{{ $model->labels[$i] }}",
+                            'label': "{!! $model->labels[$i] !!}",
                             'value': {{ $model->values[$i] }},
                         },
                     @endfor

--- a/resources/views/fusioncharts/pie.blade.php
+++ b/resources/views/fusioncharts/pie.blade.php
@@ -43,7 +43,7 @@
                 'data': [
                     @for($i = 0; $i < count($model->values); $i++)
                         {
-                            'label': "{{ $model->labels[$i] }}",
+                            'label': "{!! $model->labels[$i] !!}",
                             'value': {{ $model->values[$i] }},
                             @if($model->colors)
                                 'color': "{{ $model->colors[$i] }}",

--- a/resources/views/google/area.blade.php
+++ b/resources/views/google/area.blade.php
@@ -5,7 +5,7 @@
         var data = google.visualization.arrayToDataTable([
             ['Element', "{!! $model->element_label !!}"],
             @for ($i = 0; $i < count($model->values); $i++)
-                ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
             @endfor
         ])
 

--- a/resources/views/google/bar.blade.php
+++ b/resources/views/google/bar.blade.php
@@ -10,7 +10,7 @@
             ],
             @for ($i = 0; $i < count($model->values); $i++)
                 [
-                    "{{ $model->labels[$i] }}", {{ $model->values[$i] }}
+                    "{!! $model->labels[$i] !!}", {{ $model->values[$i] }}
                     @if($model->colors)
                         ,"{{ $model->colors[$i] }}"
                     @endif

--- a/resources/views/google/donut.blade.php
+++ b/resources/views/google/donut.blade.php
@@ -5,7 +5,7 @@
         var data = google.visualization.arrayToDataTable([
             ['Element', 'Value'],
             @for ($l = 0; $l < count($model->values); $l++)
-                ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
             @endfor
         ])
 

--- a/resources/views/google/line.blade.php
+++ b/resources/views/google/line.blade.php
@@ -6,7 +6,7 @@
             [
                 'Element', "{!! $model->element_label !!}"],
                 @for ($i = 0; $i < count($model->values); $i++)
-                    ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                    ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
                 @endfor
         ])
 

--- a/resources/views/google/pie.blade.php
+++ b/resources/views/google/pie.blade.php
@@ -5,7 +5,7 @@
         var data = google.visualization.arrayToDataTable([
             ['Element', 'Value'],
             @for($i = 0; $i < count($model->values); $i++)
-                ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
             @endfor
         ])
 

--- a/resources/views/highcharts/area.blade.php
+++ b/resources/views/highcharts/area.blade.php
@@ -19,7 +19,7 @@
             @endif
             xAxis: {
                 title: {
-                    text: "{{ $model->x_axis_title }}"
+                    text: "{!! $model->x_axis_title !!}"
                 },
                 categories: [
                     @foreach($model->labels as $label)
@@ -29,7 +29,7 @@
             },
             yAxis: {
                 title: {
-                    text: "{{ $model->y_axis_title === null ? $model->element_label : $model->y_axis_title }}"
+                    text: "{!! $model->y_axis_title === null ? $model->element_label : $model->y_axis_title !!}"
                 },
                 plotLines: [{
                     value: 0,

--- a/resources/views/highcharts/bar.blade.php
+++ b/resources/views/highcharts/bar.blade.php
@@ -31,7 +31,7 @@
             },
             xAxis: {
                 title: {
-                    text: "{{ $model->x_axis_title }}"
+                    text: "{!! $model->x_axis_title !!}"
                 },
                 categories: [
                     @foreach($model->labels as $label)
@@ -41,7 +41,7 @@
             },
             yAxis: {
                 title: {
-                    text: "{{ $model->y_axis_title === null ? $model->element_label : $model->y_axis_title }}"
+                    text: "{!! $model->y_axis_title === null ? $model->element_label : $model->y_axis_title !!}"
                 },
             },
             legend: {

--- a/resources/views/highcharts/donut.blade.php
+++ b/resources/views/highcharts/donut.blade.php
@@ -51,7 +51,7 @@
                 data: [
                     @for ($l = 0; $l < count($model->values); $l++)
                         {
-                            name: "{{ $model->labels[$l] }}",
+                            name: "{!! $model->labels[$l] !!}",
                             y: {{ $model->values[$l] }}
                         },
                     @endfor

--- a/resources/views/highcharts/line.blade.php
+++ b/resources/views/highcharts/line.blade.php
@@ -28,7 +28,7 @@
             },
             yAxis: {
                 title: {
-                    text: "{{ $model->y_axis_title === null ? $model->element_label : $model->y_axis_title }}"
+                    text: "{!! $model->y_axis_title === null ? $model->element_label : $model->y_axis_title !!}"
                 },
                 plotLines: [{
                     value: 0,

--- a/resources/views/highcharts/multi/area.blade.php
+++ b/resources/views/highcharts/multi/area.blade.php
@@ -43,7 +43,7 @@
             series: [
                 @for ($i = 0; $i < count($model->datasets); $i++)
                     {
-                        name:  "{{ $model->datasets[$i]['label'] }}",
+                        name:  "{!! $model->datasets[$i]['label'] !!}",
                         @if($model->colors && count($model->colors) > $i)
                             color: "{{ $model->colors[$i] }}",
                         @endif

--- a/resources/views/highcharts/multi/areaspline.blade.php
+++ b/resources/views/highcharts/multi/areaspline.blade.php
@@ -51,7 +51,7 @@
             series: [
                 @for ($i = 0; $i < count($model->datasets); $i++)
                     {
-                        name:  "{{ $model->datasets[$i]['label'] }}",
+                        name:  "{!! $model->datasets[$i]['label'] !!}",
                         @if($model->colors && count($model->colors) > $i)
                             color: "{{ $model->colors[$i] }}",
                         @endif

--- a/resources/views/highcharts/multi/bar.blade.php
+++ b/resources/views/highcharts/multi/bar.blade.php
@@ -45,7 +45,7 @@
             series: [
                 @for ($i = 0; $i < count($model->datasets); $i++)
                     {
-                        name:  "{{ $model->datasets[$i]['label'] }}",
+                        name:  "{!! $model->datasets[$i]['label'] !!}",
                         @if($model->colors && count($model->colors) > $i)
                             color: "{{ $model->colors[$i] }}",
                         @endif

--- a/resources/views/highcharts/multi/line.blade.php
+++ b/resources/views/highcharts/multi/line.blade.php
@@ -40,7 +40,7 @@
             series: [
                 @for ($i = 0; $i < count($model->datasets); $i++)
                     {
-                        name:  "{{ $model->datasets[$i]['label'] }}",
+                        name:  "{!! $model->datasets[$i]['label'] !!}",
                         @if($model->colors && count($model->colors) > $i)
                             color: "{{ $model->colors[$i] }}",
                         @endif

--- a/resources/views/highcharts/pie.blade.php
+++ b/resources/views/highcharts/pie.blade.php
@@ -50,7 +50,7 @@
                 data: [
                     @for($i = 0; $i < count($model->values); $i++)
                         {
-                            name: "{{ $model->labels[$i] }}",
+                            name: "{!! $model->labels[$i] !!}",
                             y: {{ $model->values[$i] }}
                         },
                     @endfor

--- a/resources/views/material/bar.blade.php
+++ b/resources/views/material/bar.blade.php
@@ -12,7 +12,7 @@
                 @endif
             ],
                 @for($i = 0; $i < count($model->values); $i++)
-                    ["{{ $model->labels[$i] }}", {{ $model->values[$i] }},"{{ $model->colors[$i] }}"],
+                    ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }},"{{ $model->colors[$i] }}"],
                 @endfor
         ])
 

--- a/resources/views/material/line.blade.php
+++ b/resources/views/material/line.blade.php
@@ -6,7 +6,7 @@
         var data = google.visualization.arrayToDataTable([
             ['', "{!! $model->element_label !!}"],
             @for($i = 0; $i < count($model->values); $i++)
-                ["{{ $model->labels[$i] }}", {{ $model->values[$i] }}],
+                ["{!! $model->labels[$i] !!}", {{ $model->values[$i] }}],
             @endfor
         ])
 

--- a/resources/views/minimalist/_data/one-indcolor.blade.php
+++ b/resources/views/minimalist/_data/one-indcolor.blade.php
@@ -1,7 +1,7 @@
 var data = [
     @for($i = 0; $i < count($model->values); $i++)
         {
-            x: "{{ $model->labels[$i] }}",
+            x: "{!! $model->labels[$i] !!}",
             y: {{ $model->values[$i] }},
             @if($model->colors)
                 color: "{{ $model->colors[$i] }}"

--- a/resources/views/minimalist/_data/one.blade.php
+++ b/resources/views/minimalist/_data/one.blade.php
@@ -1,7 +1,7 @@
 var data = [
     @for($i = 0; $i < count($model->values); $i++)
         {
-            x: "{{ $model->labels[$i] }}",
+            x: "{!! $model->labels[$i] !!}",
             y: {{ $model->values[$i] }},
         },
     @endfor

--- a/resources/views/morris/area.blade.php
+++ b/resources/views/morris/area.blade.php
@@ -8,7 +8,7 @@
             data: [
                 @for ($i = 0; $i < count($model->values); $i++)
                     {
-                        x: "{{ $model->labels[$i] }}",
+                        x: "{!! $model->labels[$i] !!}",
                         y: {{ $model->values[$i] }}
                     },
                 @endfor

--- a/resources/views/morris/bar.blade.php
+++ b/resources/views/morris/bar.blade.php
@@ -8,7 +8,7 @@
             data: [
                 @for ($i = 0; $i < count($model->values); $i++)
                     {
-                        x: "{{ $model->labels[$i] }}",
+                        x: "{!! $model->labels[$i] !!}",
                         y: {{ $model->values[$i] }}
                     },
                 @endfor

--- a/resources/views/morris/donut.blade.php
+++ b/resources/views/morris/donut.blade.php
@@ -8,7 +8,7 @@
             data: [
                 @for($i = 0; $i < count($model->values); $i++)
                     {
-                        label: "{{ $model->labels[$i] }}",
+                        label: "{!! $model->labels[$i] !!}",
                         value: "{{ $model->values[$i] }}"
                     },
                 @endfor

--- a/resources/views/plottablejs/_data/one.blade.php
+++ b/resources/views/plottablejs/_data/one.blade.php
@@ -1,7 +1,7 @@
 var data = [
     @for($i = 0; $i < count($model->values); $i++)
         {
-            x: "{{ $model->labels[$i] }}",
+            x: "{!! $model->labels[$i] !!}",
             y: {{ $model->values[$i] }},
             @if($model->colors)
                 color: "{{ $model->colors[$i] }}"


### PR DESCRIPTION
I found some more label and name, which didn't display non-english characters the right way. This fix correct this display for same libraries and chart type.