### PR TITLE
Replacing Chart::randomString with Laravel's str_random

### DIFF
--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -460,7 +460,7 @@ class Chart
      */
     public function render()
     {
-        $this->id = $this->container ? $this->container : $this->randomString();
+        $this->id = $this->container ? $this->container : str_random(10);
 
         if (! $this->labels && ! $this->values) {
             $this->labels = ['No Data Set'];
@@ -552,11 +552,11 @@ class Chart
      * Return a random string.
      *
      * @param int $length
-     *
+     * @deprecated
      * @return string
      */
     public function randomString($length = 10)
     {
-        return substr(str_shuffle(str_repeat($x = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil($length / strlen($x)))), 1, $length);
+        return str_random($length);
     }
 }


### PR DESCRIPTION
Instead of using package-level method, it is a good idea to use Laravel's Str::random ([Str.php#L234](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Support/Str.php#L234)).