### PR TITLE
Fixed "Class 'View' not found" error

### DIFF
--- a/src/Builder/Chart.php
+++ b/src/Builder/Chart.php
@@ -10,7 +10,7 @@
 
 namespace ConsoleTVs\Charts\Builder;
 
-use View;
+use Illuminate\Support\Facades\View;
 use ConsoleTVs\Support\Helpers;
 use ConsoleTVs\Charts\Traits\Setters;
 


### PR DESCRIPTION
This throws an error with the message "Class 'View' not found" on line 186.
I'm running Laravel 5.5