### PR TITLE
Fixing "horizontalbar" is not a chart type error.

### DIFF
--- a/src/Classes/BaseChart.php
+++ b/src/Classes/BaseChart.php
@@ -264,7 +264,7 @@ class BaseChart
      */
     public function formatType()
     {
-        return strtolower($this->type ? $this->type : $this->datasets[0]->type);
+        return $this->type ? $this->type : $this->datasets[0]->type;
     }
 
     /**

--- a/src/Classes/Chartjs/Dataset.php
+++ b/src/Classes/Chartjs/Dataset.php
@@ -35,7 +35,7 @@ class Dataset extends DatasetClass
         return array_merge($this->options, [
             'data'  => $this->values,
             'label' => $this->name,
-            'type'  => strtolower($this->type),
+            'type'  => $this->type,
         ]);
     }
 }


### PR DESCRIPTION
Getting an error when trying to use the chartjs "horizontalBar", because of the strtolower() method.

Horizontal Bar Example:
http://www.chartjs.org/samples/latest/charts/bar/horizontal.html

Horizontal Bar Docs:
http://www.chartjs.org/docs/latest/charts/bar.html?h=horizontal%20bar%20chart