### PR TITLE
add fallback for Laravel <= 5.4

### DIFF
--- a/src/Commands/ChartsCommand.php
+++ b/src/Commands/ChartsCommand.php
@@ -51,11 +51,12 @@ class ChartsCommand extends GeneratorCommand
         // Fallback for Laravel <= 5.4
         if (is_callable('parent::handle')) {
             parent::handle();
+            $name = $this->qualifyClass($this->getNameInput());
         } else {
             parent::fire();
+            $name = $this->parseName($this->getNameInput());
         }
 
-        $name = $this->qualifyClass($this->getNameInput());
         $path = $this->getPath($name);
 
         $this->info("[Charts] Chart created! - Location: {$path}");

--- a/src/Commands/ChartsCommand.php
+++ b/src/Commands/ChartsCommand.php
@@ -57,6 +57,12 @@ class ChartsCommand extends GeneratorCommand
             $name = $this->parseName($this->getNameInput());
         }
 
+        if (is_callable([$this, 'qualifyClass'])) {
+            $name = $this->qualifyClass($this->getNameInput());
+        } else {
+            $name = $this->parseName($this->getNameInput());
+        }
+
         $path = $this->getPath($name);
 
         $this->info("[Charts] Chart created! - Location: {$path}");


### PR DESCRIPTION
add fallback for Laravel <= 5.4

if not , output:
```
[Symfony\Component\Debug\Exception\FatalThrowableError]                            
  Call to undefined method ConsoleTVs\Charts\Commands\ChartsCommand::qualifyClass()
```