### PR TITLE
Remove closure controller

### DIFF
--- a/src/ChartsController.php
+++ b/src/ChartsController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConsoleTVs\Charts;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class ChartsController extends BaseController
+{
+    public function __invoke(Request $request)
+    {
+        $chartRouteName = Str::afterLast($request->path(), '/');
+
+        if (! ($chartClass = Cache::get(config('charts.cache_key_prefix') . '.' . $chartRouteName))) {
+            abort(404);
+        }
+
+        $chart = new $chartClass();
+
+        return new JsonResponse($chart->handler($request)->toObject());
+    }
+}

--- a/src/Config/charts.php
+++ b/src/Config/charts.php
@@ -41,4 +41,6 @@ return [
     |
     */
     'global_route_name_prefix' => 'charts',
+
+    'cache_key_prefix' => 'charts.routes',
 ];


### PR DESCRIPTION
This allow us to cache the routes via : artisan route:cache

It uses the cache repository to store which chart route name is linked to which class (since the chart route name must be unique).