### PR TITLE
Add support for Laravel 8 to charts v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "library",
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.0|^6.0",
-        "illuminate/console": "^5.0|^6.0",
+        "illuminate/support": "^5.0|^6.0|^7.0",
+        "illuminate/console": "^5.0|^6.0|^7.0",
         "balping/json-raw-encoder": "^1.0"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "type": "library",
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "^5.0|^6.0|^7.0",
-        "illuminate/console": "^5.0|^6.0|^7.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/console": "^5.0|^6.0|^7.0|^8.0",
         "balping/json-raw-encoder": "^1.0"
     },
     "authors": [


### PR DESCRIPTION
First of all:
- _I know_ v6 is unsupported and unmaintained; I know 😄 
- _I know_ v7 is much better than v6; I know 😄 

But. Hear me out.

![Screenshot 2020-09-08 at 07 26 10](https://user-images.githubusercontent.com/1032474/92476072-620e6180-f1ac-11ea-8263-d2405ba5f9c5.png)

From the chart above:
- more than 1000 people install `v6` every day
- only ~70 people install `v7` every day

**Since more than 90% of consoletvs/charts users are still on v6, I think adding Laravel 8 support to charts v6** (while _still keeping v6 as unmaintained and unsupported_) **would make thousands of people happy**, because they have just _a little more time_ to gather the resources to upgrade to v7. We still need to convince clients to budget it, figure out exactly _how to do it_, things like that.

In the meantime, **I can help create a much-needed upgrade guide from charts v6 to v7**. So that we make it _much easier_ and less scary for people to upgrade their charts from v6 to v7.

**Will you accept my help in making it easier for users to upgrade to v7?** I know I have thousands of [Backpack for Laravel](https://github.com/laravel-backpack/crud) users that still depend on charts v6, but are currently stuck in a very difficult spot. 

If you're ok with merging this, here's how I propose we do it:
- [x] create a `v6` branch from commit 524257b (last released version of v6 - 6.5.4): 
```bash
git checkout 524257b
git checkout -b v6
git push origin v6
```
- [x] modify this PR to point to the `v6` branch instead of `master`;
- [x] merge this PR into `v6`;
- [ ] tag the v6 branch after the merge with `6.5.5`;

Let me know if you need my help with any of the above. But unfortunately I don't have write access to the repo.

In the end:
- we'll have a new branch, `v6`, which is easier to work on;
- `v6` users will be able to upgrade to Laravel 8 without a hitch;
- you won't be bugged by dozens of issues (or more) requesting this (you know it's coming! :laugh);

Afterwards:
- I plan to add [the v6 docs link](https://github.com/ConsoleTVs/ChartsDocs/tree/fd537ee2a3f2652925b106274ff7031bef0c9585/docs) somewhere so people still have easy access to them; so they don't ask in the issues; 
- as I add support for Charts v7 to Backpack for Laravel, and upgrade by own charts, I can help you write an upgrade guide, from v6 to v7;

**I think this will make A LOT of people happy, and provide an easier upgrade path from charts v6 to v7. What do you think** @ConsoleTVs ?

PS. Of course, I've tested this PR, and charts v6 works well with Laravel 8 just by bumping the versions:
![2020-09-08 06 22 36](https://user-images.githubusercontent.com/1032474/92477217-3ab89400-f1ae-11ea-8fc9-b2cf09a9881c.gif)
