### PR TITLE
add v6 mention to v7 readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ The documentation for the latest version of charts can be found here by pressing
 
 <p align="center"><img src="https://image.prntscr.com/image/pwONtZIUSOGnxud9Omh4-Q.png"></p>
 
+
+## Previous Version
+
+Unfortunately laravel-charts `v7` is incompatible with our previous version, `v6`, because it has involved [a heavy rewrite](https://github.com/ConsoleTVs/Charts/releases/tag/7.0.0). If you're still stuck on `v6`, you should use:
+- the [`v6` branch of this repo](https://github.com/ConsoleTVs/Charts/tree/v6);
+- the [`v6` version of the documentation](https://v6.charts.erik.cat);
+
+Please note that we consider `v6` unmaintained and unsupported. So you should upgrade to `v7` as soon as possible. We're currently working on an upgrade guide. If you can help, please reach out with an issue - we'll take all the help we can get.
+
 ## License
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FConsoleTVs%2FCharts.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FConsoleTVs%2FCharts?ref=badge_large)


### PR DESCRIPTION
This PR adds a new section to the v7 README.md file, to direct v6 users to the correct docs or branch.