### PR TITLE
Fix to error: trim() expects parameter 1 to be string, array given, w…

### DIFF
--- a/src/Classes/BaseChart.php
+++ b/src/Classes/BaseChart.php
@@ -186,7 +186,7 @@ class BaseChart
     public function options($options, bool $overwrite = false)
     {
         if (!empty($options['plugins'])) {
-            $options['plugins'] = new Raw(trim(preg_replace('/\s\s+/', ' ', $options['plugins'])));
+            $options['plugins'] = new Raw(trim((string) trim(preg_replace('/\s\s+/', ' ', $options['plugins'])));
         }
 
         if ($options instanceof Collection) {


### PR DESCRIPTION
…hen using function options with plugins

EJ: 

 $chart->options([
            'plugins' => [
                'colorschemes' => [
                    'scheme' => 'tableau.Classic10'
                ]
            ]
        ]);